### PR TITLE
[Weekly 6] 대학 정보 반환 API 구현

### DIFF
--- a/src/main/java/com/kakao/uniscope/college/dto/CollegeDto.java
+++ b/src/main/java/com/kakao/uniscope/college/dto/CollegeDto.java
@@ -1,0 +1,15 @@
+package com.kakao.uniscope.college.dto;
+
+import com.kakao.uniscope.college.entity.College;
+
+public record CollegeDto(
+        Long collegeSeq,
+        String collegeName
+) {
+    public static CollegeDto from(College college) {
+        return new CollegeDto(
+                college.getCollegeSeq(),
+                college.getCollegeName()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/college/entity/College.java
+++ b/src/main/java/com/kakao/uniscope/college/entity/College.java
@@ -1,0 +1,25 @@
+package com.kakao.uniscope.college.entity;
+
+import com.kakao.uniscope.univ.entity.University;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "COLLEGE")
+@Getter
+public class College {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "COLLEGE_SEQ")
+    private Long collegeSeq;
+
+    @Column(name = "COLLEGE_NAME")
+    private String collegeName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "UNIV_SEQ")
+    private University university;
+
+    protected College() {}
+}

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface CollegeRepository extends JpaRepository<College,Long> {
+public interface CollegeRepository extends JpaRepository<College, Long> {
     List<College> findByUniversity_UnivSeq(Long univSeq);
 }

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
@@ -1,0 +1,12 @@
+package com.kakao.uniscope.college.repository;
+
+import com.kakao.uniscope.college.entity.College;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CollegeRepository extends JpaRepository<College,Long> {
+    List<College> findByUniversity_UnivSeq(Long univSeq);
+}

--- a/src/main/java/com/kakao/uniscope/univ/controller/UnivController.java
+++ b/src/main/java/com/kakao/uniscope/univ/controller/UnivController.java
@@ -1,0 +1,29 @@
+package com.kakao.uniscope.univ.controller;
+
+import com.kakao.uniscope.univ.dto.UnivResponseDto;
+import com.kakao.uniscope.univ.service.UnivService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/univ")
+public class UnivController {
+
+    private final UnivService univService;
+
+    public UnivController(UnivService univService) {
+        this.univService = univService;
+    }
+
+    @GetMapping("/{univSeq}")
+    public ResponseEntity<UnivResponseDto> getUniversityDetails(@PathVariable Long univSeq) {
+
+        UnivResponseDto responseDto = univService.getUniversityDetails(univSeq);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/univ/dto/UnivResponseDto.java
+++ b/src/main/java/com/kakao/uniscope/univ/dto/UnivResponseDto.java
@@ -1,0 +1,12 @@
+package com.kakao.uniscope.univ.dto;
+
+import com.kakao.uniscope.college.dto.CollegeDto;
+import com.kakao.uniscope.univ.review.dto.UnivReviewSummaryDto;
+
+import java.util.List;
+
+public record UnivResponseDto(
+        UniversityDto university,
+        List<CollegeDto> colleges,
+        List<UnivReviewSummaryDto> univReviews
+) {}

--- a/src/main/java/com/kakao/uniscope/univ/dto/UniversityDto.java
+++ b/src/main/java/com/kakao/uniscope/univ/dto/UniversityDto.java
@@ -1,0 +1,27 @@
+package com.kakao.uniscope.univ.dto;
+
+import com.kakao.uniscope.univ.entity.University;
+
+public record UniversityDto(
+        Long univSeq,
+        String name,
+        String address,
+        String tel,
+        String homePage,
+        String image,
+        String establishedYear,
+        Integer totalStudent
+) {
+    public static UniversityDto from(University univ) {
+        return new UniversityDto(
+                univ.getUnivSeq(),
+                univ.getName(),
+                univ.getAddress(),
+                univ.getTel(),
+                univ.getHomePage(),
+                univ.getImageUrl(),
+                univ.getEstablishedYear(),
+                univ.getTotalStudent()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/univ/entity/University.java
+++ b/src/main/java/com/kakao/uniscope/univ/entity/University.java
@@ -1,0 +1,49 @@
+package com.kakao.uniscope.univ.entity;
+
+import com.kakao.uniscope.college.entity.College;
+import com.kakao.uniscope.univ.review.entity.UnivReview;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "UNIV")
+@Getter
+public class University {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "UNIV_SEQ")
+    private Long univSeq;
+
+    @Column(name = "NAME")
+    private String name;
+
+    @Column(name = "ADDRESS")
+    private String address;
+
+    @Column(name = "TEL")
+    private String tel;
+
+    @Column(name = "HOME_PAGE")
+    private String homePage;
+
+    @Column(name = "IMAGE")
+    private String imageUrl;
+
+    @Column(name = "ESTABLISHED_YEAR")
+    private String establishedYear;
+
+    @Column(name = "STUDENT_NUM")
+    private Integer totalStudent;
+
+    @OneToMany(mappedBy = "university", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<College> colleges = new ArrayList<>();
+
+    @OneToMany(mappedBy = "university", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UnivReview> reviews = new ArrayList<>();
+
+    protected University() {}
+}

--- a/src/main/java/com/kakao/uniscope/univ/repository/UnivRepository.java
+++ b/src/main/java/com/kakao/uniscope/univ/repository/UnivRepository.java
@@ -1,0 +1,8 @@
+package com.kakao.uniscope.univ.repository;
+
+import com.kakao.uniscope.univ.entity.University;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UnivRepository extends JpaRepository<University,Long> { }

--- a/src/main/java/com/kakao/uniscope/univ/repository/UnivRepository.java
+++ b/src/main/java/com/kakao/uniscope/univ/repository/UnivRepository.java
@@ -5,4 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UnivRepository extends JpaRepository<University,Long> { }
+public interface UnivRepository extends JpaRepository<University, Long> { }

--- a/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewSummaryDto.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewSummaryDto.java
@@ -1,0 +1,17 @@
+package com.kakao.uniscope.univ.review.dto;
+
+import com.kakao.uniscope.univ.review.entity.UnivReview;
+
+import java.time.LocalDateTime;
+
+public record UnivReviewSummaryDto(
+        Long univReviewSeq,
+        LocalDateTime createDate
+) {
+    public static UnivReviewSummaryDto from(UnivReview univReview) {
+        return new UnivReviewSummaryDto(
+                univReview.getUnivReviewSeq(),
+                univReview.getCreateDate()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewSummaryDto.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewSummaryDto.java
@@ -6,11 +6,15 @@ import java.time.LocalDateTime;
 
 public record UnivReviewSummaryDto(
         Long univReviewSeq,
+        Integer overallScore,
+        String reviewText,
         LocalDateTime createDate
 ) {
     public static UnivReviewSummaryDto from(UnivReview univReview) {
         return new UnivReviewSummaryDto(
                 univReview.getUnivReviewSeq(),
+                univReview.getOverallScore(),
+                univReview.getReviewText(),
                 univReview.getCreateDate()
         );
     }

--- a/src/main/java/com/kakao/uniscope/univ/review/entity/UnivReview.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/entity/UnivReview.java
@@ -1,0 +1,48 @@
+package com.kakao.uniscope.univ.review.entity;
+
+import com.kakao.uniscope.univ.entity.University;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "UNIV_REVIEW")
+@Getter
+public class UnivReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "UNIV_REVIEW_SEQ")
+    private Long univReviewSeq;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "UNIV_SEQ")
+    private University university;
+
+    @Column(name = "FOOD")
+    private Integer foodScore;
+
+    @Column(name = "DORM")
+    private Integer dormScore;
+
+    @Column(name = "CONV")
+    private Integer convScore;
+
+    @Column(name = "CAMPUS")
+    private Integer campusScore;
+
+    @Column(name = "OVER_ALL")
+    private Integer overallScore;
+
+    @Column(name = "REVIEW_TXT")
+    private String reviewText;
+
+    @Column(name = "CREATE_USER")
+    private String createUser;
+
+    @Column(name = "CREATE_DATE")
+    private LocalDateTime createDate;
+
+    protected UnivReview() {}
+}

--- a/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepository.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepository.java
@@ -1,0 +1,13 @@
+package com.kakao.uniscope.univ.review.repository;
+
+import com.kakao.uniscope.univ.entity.University;
+import com.kakao.uniscope.univ.review.entity.UnivReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UnivReviewRepository extends JpaRepository<UnivReview, Long> {
+    List<UnivReview> findTop3ByUniversityOrderByCreateDateDesc(University university);
+}

--- a/src/main/java/com/kakao/uniscope/univ/service/UnivService.java
+++ b/src/main/java/com/kakao/uniscope/univ/service/UnivService.java
@@ -1,0 +1,53 @@
+package com.kakao.uniscope.univ.service;
+
+import com.kakao.uniscope.college.dto.CollegeDto;
+import com.kakao.uniscope.college.entity.College;
+import com.kakao.uniscope.college.repository.CollegeRepository;
+import com.kakao.uniscope.univ.dto.UnivResponseDto;
+import com.kakao.uniscope.univ.dto.UniversityDto;
+import com.kakao.uniscope.univ.entity.University;
+import com.kakao.uniscope.univ.repository.UnivRepository;
+import com.kakao.uniscope.univ.review.dto.UnivReviewSummaryDto;
+import com.kakao.uniscope.univ.review.entity.UnivReview;
+import com.kakao.uniscope.univ.review.repository.UnivReviewRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+public class UnivService {
+
+    private final UnivRepository univRepository;
+    private final CollegeRepository collegeRepository;
+    private final UnivReviewRepository univReviewRepository;
+
+    public UnivService(
+            UnivRepository univRepository,
+            CollegeRepository collegeRepository,
+            UnivReviewRepository univReviewRepository
+    ) {
+        this.univRepository = univRepository;
+        this.collegeRepository = collegeRepository;
+        this.univReviewRepository = univReviewRepository;
+    }
+
+    public UnivResponseDto getUniversityDetails(Long univSeq) {
+        University university = univRepository.findById(univSeq)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        List<College> colleges = collegeRepository.findByUniversity_UnivSeq(univSeq);
+        List<UnivReview> recentReviews = univReviewRepository.findTop3ByUniversityOrderByCreateDateDesc(university);
+
+        List<CollegeDto> collegeDtos = colleges.stream()
+                .map(CollegeDto::from)
+                .toList();
+
+        List<UnivReviewSummaryDto> reviewDtos = recentReviews.stream()
+                .map(UnivReviewSummaryDto::from)
+                .toList();
+
+        return new UnivResponseDto(UniversityDto.from(university), collegeDtos, reviewDtos);
+    }
+}

--- a/src/test/java/com/kakao/uniscope/univ/UnivControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/UnivControllerTest.java
@@ -1,0 +1,72 @@
+package com.kakao.uniscope.univ;
+
+import com.kakao.uniscope.college.dto.CollegeDto;
+import com.kakao.uniscope.univ.controller.UnivController;
+import com.kakao.uniscope.univ.dto.UnivResponseDto;
+import com.kakao.uniscope.univ.dto.UniversityDto;
+import com.kakao.uniscope.univ.review.dto.UnivReviewSummaryDto;
+import com.kakao.uniscope.univ.service.UnivService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UnivController.class)
+public class UnivControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UnivService univService;
+
+    @Test
+    @DisplayName("대학교 상세 정보 조회 성공")
+    void getUniversityDetails_Success() throws Exception {
+        // given
+        Long univSeq = 1L;
+        UnivResponseDto mockResponseDto = createMockResponseDto();
+        when(univService.getUniversityDetails(univSeq)).thenReturn(mockResponseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/univ/{univSeq}", univSeq)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.university.univSeq").value(univSeq));
+    }
+
+    @Test
+    @DisplayName("대학교 상세 정보 조회 실패 - 리소스 없음")
+    void getUniversityDetails_NotFound() throws Exception {
+        // given: 서비스에서 ResponseStatusException을 던지도록 Mocking
+        Long univSeq = 999L;
+        when(univService.getUniversityDetails(univSeq)).thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        // when & then: API 호출 및 404 응답 검증
+        mockMvc.perform(get("/api/univ/{univSeq}", univSeq)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    private UnivResponseDto createMockResponseDto() {
+        UniversityDto universityDto = new UniversityDto(1L, "충남대학교", "대전", "042", "cnu.ac.kr", "image.png", "1952", 28000);
+        List<CollegeDto> collegeDtos = Collections.emptyList();
+        List<UnivReviewSummaryDto> reviewDtos = List.of(new UnivReviewSummaryDto(10L, LocalDateTime.now()));
+        return new UnivResponseDto(universityDto, collegeDtos, reviewDtos);
+    }
+
+}

--- a/src/test/java/com/kakao/uniscope/univ/UnivControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/UnivControllerTest.java
@@ -65,7 +65,7 @@ public class UnivControllerTest {
     private UnivResponseDto createMockResponseDto() {
         UniversityDto universityDto = new UniversityDto(1L, "충남대학교", "대전", "042", "cnu.ac.kr", "image.png", "1952", 28000);
         List<CollegeDto> collegeDtos = Collections.emptyList();
-        List<UnivReviewSummaryDto> reviewDtos = List.of(new UnivReviewSummaryDto(10L, LocalDateTime.now()));
+        List<UnivReviewSummaryDto> reviewDtos = List.of(new UnivReviewSummaryDto(10L, 4, "대학 리뷰", LocalDateTime.now()));
         return new UnivResponseDto(universityDto, collegeDtos, reviewDtos);
     }
 

--- a/src/test/java/com/kakao/uniscope/univ/UnivServiceTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/UnivServiceTest.java
@@ -1,0 +1,91 @@
+package com.kakao.uniscope.univ;
+
+import com.kakao.uniscope.college.entity.College;
+import com.kakao.uniscope.college.repository.CollegeRepository;
+import com.kakao.uniscope.univ.dto.UnivResponseDto;
+import com.kakao.uniscope.univ.entity.University;
+import com.kakao.uniscope.univ.repository.UnivRepository;
+import com.kakao.uniscope.univ.review.entity.UnivReview;
+import com.kakao.uniscope.univ.review.repository.UnivReviewRepository;
+import com.kakao.uniscope.univ.service.UnivService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UnivServiceTest {
+
+    @Mock
+    private UnivRepository univRepository;
+
+    @Mock
+    private CollegeRepository collegeRepository;
+
+    @Mock
+    private UnivReviewRepository univReviewRepository;
+
+    @InjectMocks
+    private UnivService univService;
+
+    @Test
+    @DisplayName("대학교 상세 정보 조회 성공")
+    void getUniversityDetails_Success() {
+        Long univSeq = 1L;
+
+        // 대학 엔티티
+        University mockUniv = mock(University.class);
+        when(mockUniv.getUnivSeq()).thenReturn(univSeq);
+        when(mockUniv.getName()).thenReturn("충남대학교");
+
+        // 단과 대학 엔티티
+        College mockCollege = mock(College.class);
+        when(mockCollege.getCollegeSeq()).thenReturn(1L);
+        when(mockCollege.getCollegeName()).thenReturn("공과대학");
+        List<College> mockColleges = List.of(mockCollege);
+
+        // 대학 평가 엔티티
+        UnivReview mockReview = mock(UnivReview.class);
+        when(mockReview.getUnivReviewSeq()).thenReturn(10L);
+        when(mockReview.getCreateDate()).thenReturn(LocalDateTime.now());
+        List<UnivReview> mockReviews = List.of(mockReview);
+
+        when(univRepository.findById(univSeq)).thenReturn(Optional.of(mockUniv));
+        when(collegeRepository.findByUniversity_UnivSeq(univSeq)).thenReturn(mockColleges);
+        when(univReviewRepository.findTop3ByUniversityOrderByCreateDateDesc(any(University.class))).thenReturn(mockReviews);
+
+        UnivResponseDto result = univService.getUniversityDetails(univSeq);
+
+        // then: 결과 검증
+        assertNotNull(result);
+        assertEquals("충남대학교", result.university().name());
+        assertEquals(1, result.colleges().size());
+        assertEquals(1, result.univReviews().size());
+
+        // 리포지토리 메서드가 올바르게 호출되었는지 확인
+        verify(univRepository, times(1)).findById(univSeq);
+        verify(collegeRepository, times(1)).findByUniversity_UnivSeq(univSeq);
+        verify(univReviewRepository, times(1)).findTop3ByUniversityOrderByCreateDateDesc(any(University.class));
+    }
+
+    @Test
+    @DisplayName("대학교 상세 정보 조회 실패 - 리소스 없음")
+    void getUniversityDetails_NotFound() {
+        Long univSeq = 999L;
+        when(univRepository.findById(univSeq)).thenReturn(Optional.empty());
+
+        assertThrows(ResponseStatusException.class, () -> univService.getUniversityDetails(univSeq));
+        verify(univRepository, times(1)).findById(univSeq);
+    }
+}

--- a/src/test/java/com/kakao/uniscope/univ/UnivServiceTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/UnivServiceTest.java
@@ -58,6 +58,8 @@ public class UnivServiceTest {
         // 대학 평가 엔티티
         UnivReview mockReview = mock(UnivReview.class);
         when(mockReview.getUnivReviewSeq()).thenReturn(10L);
+        when(mockReview.getOverallScore()).thenReturn(4);
+        when(mockReview.getReviewText()).thenReturn("대학 리뷰");
         when(mockReview.getCreateDate()).thenReturn(LocalDateTime.now());
         List<UnivReview> mockReviews = List.of(mockReview);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

-  #4 

## 🚀 작업 내용

특정 대학교의 상세 정보와 관련된 단과대학 및 리뷰 요약 정보를 조회하는 API를 개발했습니다.
핵심 변경 사항은 다음과 같습니다.
- 엔티티 및 DTO 구현:
  - University, College, UnivReview 엔티티와 이들을 활용한 DTO 클래스들을 구현
 
- Repository 구현:
  - Spring Data JPA의 쿼리 메서드를 활용하여 필요한 데이터를 조회하는 리포지토리 인터페이스들을 작성

- Service 및 Controller 구현:
  - 비즈니스 로직을 담은 UnivService와 GET /api/univ/{univSeq} 엔드포인트를 처리하는 UnivController를 구현

- 테스트 코드 작성:
  - 컨트롤러와 서비스 계층에 대한 유닛 테스트 코드를 작성하여 기능의 유효성을 검증

### 📸 스크린샷

<img width="1157" height="906" alt="image" src="https://github.com/user-attachments/assets/17fbb793-2559-4cf3-9ef7-7ad20bf57b65" />

## 📢 참고 사항

- DB 스키마 변경:
  - `UNIV` 엔티티의 `YEAR` 컬럼명을 `establishedYear`로, `IMAGE` 컬럼명을 `imageUrl`로 변경했습니다.
  - `YEAR`의 경우 SQL DB에서 예약어로 지정되어 있어, 경고가 발생함
  - `IMAGE`의 경우 이미지 파일을 저장하는지, 이미지 경로를 저장하는 지가 모호하다고 생각하여 변경

- Long 타입 사용:
  - DB의 기본 키 타입을 Long으로 통일

- 대학 평가:
  - 대학 평가는 우선 생성 일자 기준 상위 3가지만을 가져오도록 구현했습니다.
  - 이후, 특정 대학의 모든 대학 평가를 불러오는 API를 구현할 계획입니다.

- 공통 코드:
  - 우선, 공동 코드(생성자, 수정자, 생성 일시 등)는 특정 필드를 제외하고 구현하지 않은 채로 개발했습니다. 

### 🖐🏼 RCA 룰

> r : 꼭 반영 해주세요 (request changes)
> c : 웬만하면 반영해주세요 (comment)
> a : 그냥 의견 혹은 칭찬(칭찬이 중요, 개발을 계속 하게 만드는 원동력이 될 수 있음) (approve)