### PR TITLE
[Weekly 7] 특정 교수 조회 API 구현

### DIFF
--- a/src/main/java/com/kakao/uniscope/lecture/entity/Lecture.java
+++ b/src/main/java/com/kakao/uniscope/lecture/entity/Lecture.java
@@ -6,6 +6,8 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -24,6 +26,7 @@ import lombok.NoArgsConstructor;
 public class Lecture {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "LEC_SEQ")
     private Integer lecSeq;
 

--- a/src/main/java/com/kakao/uniscope/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/kakao/uniscope/lecture/repository/LectureRepository.java
@@ -2,7 +2,9 @@ package com.kakao.uniscope.lecture.repository;
 
 import com.kakao.uniscope.lecture.entity.Lecture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
 
 }

--- a/src/main/java/com/kakao/uniscope/lecture/review/dto/LectureReviewSummaryDto.java
+++ b/src/main/java/com/kakao/uniscope/lecture/review/dto/LectureReviewSummaryDto.java
@@ -13,7 +13,7 @@ public record LectureReviewSummaryDto(
         Integer examDifficulty,
         String groupProjReq,
         String content,
-        LocalDateTime craetedAt
+        LocalDateTime createdDate
 ) {
     public static LectureReviewSummaryDto from(LectureReivew lectureReview) {
         return new LectureReviewSummaryDto(
@@ -26,7 +26,7 @@ public record LectureReviewSummaryDto(
                 lectureReview.getExamDifficulty(),
                 lectureReview.getGroupProjReq(),
                 lectureReview.getOverallReview(),
-                lectureReview.getCreatedAt()
+                lectureReview.getCreatedDate()
         );
     }
 }

--- a/src/main/java/com/kakao/uniscope/lecture/review/entity/LectureReivew.java
+++ b/src/main/java/com/kakao/uniscope/lecture/review/entity/LectureReivew.java
@@ -49,5 +49,5 @@ public class LectureReivew {
     private Lecture lecture;
 
     @Column(name = "CREATE_DATE")
-    private LocalDateTime createdAt;
+    private LocalDateTime createdDate;
 }

--- a/src/main/java/com/kakao/uniscope/lecture/review/entity/LectureReivew.java
+++ b/src/main/java/com/kakao/uniscope/lecture/review/entity/LectureReivew.java
@@ -4,6 +4,8 @@ import com.kakao.uniscope.lecture.entity.Lecture;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -20,6 +22,7 @@ import lombok.NoArgsConstructor;
 public class LectureReivew {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "LEC_REVIEW_SEQ")
     private Long lecReviewSeq;
 

--- a/src/main/java/com/kakao/uniscope/lecture/review/repository/LectureReviewRepository.java
+++ b/src/main/java/com/kakao/uniscope/lecture/review/repository/LectureReviewRepository.java
@@ -1,11 +1,26 @@
 package com.kakao.uniscope.lecture.review.repository;
 
-import com.kakao.uniscope.lecture.entity.Lecture;
 import com.kakao.uniscope.lecture.review.entity.LectureReivew;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface LectureReviewRepository extends JpaRepository<LectureReivew, Long> {
 
-    List<LectureReivew> findTop3ByLectureOrderByCreateDateDesc(Lecture Lecture);
+    List<LectureReivew> findTop3ByLecture_Professor_ProfSeqOrderByCreatedDateDesc(Long profSeq);
+
+    // 과제량 평균
+    @Query("SELECT AVG(lr.homework) FROM LectureReivew lr JOIN lr.lecture l WHERE l.professor.profSeq = :profSeq")
+    Double findAvgHomework(@Param("profSeq") Long profSeq);
+
+    // 수업 난이도 평균
+    @Query("SELECT AVG(lr.lecDifficulty) FROM LectureReivew lr JOIN lr.lecture l WHERE l.professor.profSeq = :profSeq")
+    Double findAvgLecDifficulty(@Param("profSeq") Long profSeq);
+
+    // 시험 난이도 평균
+    @Query("SELECT AVG(lr.examDifficulty) FROM LectureReivew lr JOIN lr.lecture l WHERE l.professor.profSeq = :profSeq")
+    Double findAvgExamDifficulty(@Param("profSeq") Long profSeq);
 }

--- a/src/main/java/com/kakao/uniscope/professor/controller/ProfController.java
+++ b/src/main/java/com/kakao/uniscope/professor/controller/ProfController.java
@@ -1,0 +1,24 @@
+package com.kakao.uniscope.professor.controller;
+
+import com.kakao.uniscope.professor.dto.ProfResponseDto;
+import com.kakao.uniscope.professor.service.ProfService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/prof")
+@RequiredArgsConstructor
+public class ProfController {
+
+    private final ProfService profService;
+
+    @GetMapping("/{prof_seq}")
+    public ResponseEntity<ProfResponseDto> getProfessorDetails(@PathVariable("prof_seq") Long profSeq) {
+        ProfResponseDto response = profService.getProfessorDetails(profSeq);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/dto/CollegeSimpleDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/CollegeSimpleDto.java
@@ -1,0 +1,15 @@
+package com.kakao.uniscope.professor.dto;
+
+import com.kakao.uniscope.college.entity.College;
+
+public record CollegeSimpleDto(
+        Long id,
+        String name
+) {
+    public static CollegeSimpleDto from(College college) {
+        return new CollegeSimpleDto(
+                college.getCollegeSeq(),
+                college.getCollegeName()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/dto/ProfResponseDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/ProfResponseDto.java
@@ -1,0 +1,10 @@
+package com.kakao.uniscope.professor.dto;
+
+import com.kakao.uniscope.lecture.review.dto.LectureReviewSummaryDto;
+import java.util.List;
+
+public record ProfResponseDto(
+        ProfessorDto professor,
+        List<LectureReviewSummaryDto> recentLectureReviews
+) {
+}

--- a/src/main/java/com/kakao/uniscope/professor/dto/ProfessorDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/ProfessorDto.java
@@ -1,0 +1,26 @@
+package com.kakao.uniscope.professor.dto;
+
+
+import com.kakao.uniscope.professor.entity.Professor;
+
+public record ProfessorDto(
+        Long id,
+        String name,
+        UniversitySimpleDto university,
+        CollegeSimpleDto college,
+        String email,
+        Double overallRating,
+        RatingBreakdownDto ratingBreakdown
+) {
+    public static ProfessorDto from(Professor professor, Double overallRating, RatingBreakdownDto ratingBreakdown) {
+        return new ProfessorDto(
+                professor.getProfSeq(),
+                professor.getProfName(),
+                UniversitySimpleDto.from(professor.getCollege().getUniversity()),
+                CollegeSimpleDto.from(professor.getCollege()),
+                professor.getProfEmail(),
+                overallRating,
+                ratingBreakdown
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/dto/RatingBreakdownDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/RatingBreakdownDto.java
@@ -1,0 +1,20 @@
+package com.kakao.uniscope.professor.dto;
+
+public record RatingBreakdownDto(
+        Double thesisPerformance,    // 논문 실적
+        Double researchPerformance,  // 연구 실적
+        Double homework,             // 과제량 평균
+        Double lectureDifficulty,    // 수업 난이도 평균
+        Double examDifficulty        // 시험 난이도 평균
+) {
+    public static RatingBreakdownDto of(Double thesisPerf, Double researchPerf,
+            Double homework, Double lecDifficulty, Double examDifficulty) {
+        return new RatingBreakdownDto(
+                thesisPerf != null ? thesisPerf : 0.0,
+                researchPerf != null ? researchPerf : 0.0,
+                homework != null ? homework : 0.0,
+                lecDifficulty != null ? lecDifficulty : 0.0,
+                examDifficulty != null ? examDifficulty : 0.0
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/dto/UniversitySimpleDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/UniversitySimpleDto.java
@@ -1,0 +1,15 @@
+package com.kakao.uniscope.professor.dto;
+
+import com.kakao.uniscope.univ.entity.University;
+
+public record UniversitySimpleDto(
+        Long id,
+        String name
+) {
+    public static UniversitySimpleDto from(University university) {
+        return new UniversitySimpleDto(
+                university.getUnivSeq(),
+                university.getName()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/entity/Professor.java
+++ b/src/main/java/com/kakao/uniscope/professor/entity/Professor.java
@@ -1,11 +1,15 @@
 package com.kakao.uniscope.professor.entity;
 
+import com.kakao.uniscope.college.entity.College;
 import com.kakao.uniscope.lecture.entity.Lecture;
 import com.kakao.uniscope.professor.review.entity.ProfReview;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
@@ -33,7 +37,10 @@ public class Professor {
     @Column(name = "HOME_PAGE")
     private String homePage;
 
-    //todo: college와 연관관계 설정
+    // todo: 추후 college를 department(학과)와 연관관계 매핑해야함 -> profdto수정도 필요
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "COLLEGE_SEQ")  // DB에서 이 컬럼으로 College와 연결
+    private College college;
 
     @OneToMany(mappedBy = "professor", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Lecture> lectures = new ArrayList<>();

--- a/src/main/java/com/kakao/uniscope/professor/entity/Professor.java
+++ b/src/main/java/com/kakao/uniscope/professor/entity/Professor.java
@@ -7,6 +7,8 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -25,6 +27,7 @@ import lombok.NoArgsConstructor;
 public class Professor {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "PROF_SEQ")
     private Long profSeq;
 

--- a/src/main/java/com/kakao/uniscope/professor/exception/ProfessorExceptionHandler.java
+++ b/src/main/java/com/kakao/uniscope/professor/exception/ProfessorExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.kakao.uniscope.professor.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ProfessorExceptionHandler {
+
+    @ExceptionHandler(ProfessorNotFoundException.class)
+    public ResponseEntity<Void> handleProfessorNotFound(ProfessorNotFoundException e) {
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/exception/ProfessorNotFoundException.java
+++ b/src/main/java/com/kakao/uniscope/professor/exception/ProfessorNotFoundException.java
@@ -1,0 +1,7 @@
+package com.kakao.uniscope.professor.exception;
+
+public class ProfessorNotFoundException extends RuntimeException{
+    public ProfessorNotFoundException(Long profSeq) {
+        super("교수를 찾을 수 없습니다. 교수 번호: " + profSeq);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/repository/ProfessorRepository.java
+++ b/src/main/java/com/kakao/uniscope/professor/repository/ProfessorRepository.java
@@ -2,7 +2,9 @@ package com.kakao.uniscope.professor.repository;
 
 import com.kakao.uniscope.professor.entity.Professor;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProfessorRepository extends JpaRepository<Professor, Long> {
 
 }

--- a/src/main/java/com/kakao/uniscope/professor/review/entity/ProfReview.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/entity/ProfReview.java
@@ -4,6 +4,8 @@ import com.kakao.uniscope.professor.entity.Professor;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -19,6 +21,7 @@ import lombok.NoArgsConstructor;
 public class ProfReview {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "PROF_REVIEW_SEQ")
     private Long profReviewSeq;
 

--- a/src/main/java/com/kakao/uniscope/professor/review/repository/ProfReviewRepository.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/repository/ProfReviewRepository.java
@@ -2,6 +2,18 @@ package com.kakao.uniscope.professor.review.repository;
 
 import com.kakao.uniscope.professor.review.entity.ProfReview;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProfReviewRepository extends JpaRepository<ProfReview, Long> {
+
+    // 논문 실적 평균
+    @Query("SELECT AVG(pr.thesisPerf) FROM ProfReview pr WHERE pr.professor.profSeq = :profSeq")
+    Double findAvgThesisPerf(@Param("profSeq") Long profSeq);
+
+    // 연구 실적 평균
+    @Query("SELECT AVG(pr.researchPerf) FROM ProfReview pr WHERE pr.professor.profSeq = :profSeq")
+    Double findAvgResearchPerf(@Param("profSeq") Long profSeq);
 }

--- a/src/main/java/com/kakao/uniscope/professor/service/ProfService.java
+++ b/src/main/java/com/kakao/uniscope/professor/service/ProfService.java
@@ -28,7 +28,7 @@ public class ProfService {
         Professor professor = findProfessorById(profSeq);
         RatingBreakdownDto ratingBreakdown = calculateRatings(profSeq);
         Double overallRating = calculateOverallRating(ratingBreakdown);
-        ProfessorDto professorDto = createProfessorDto(professor, overallRating, ratingBreakdown);
+        ProfessorDto professorDto = ProfessorDto.from(professor, overallRating, ratingBreakdown);
         List<LectureReviewSummaryDto> lectureReviews = getRecentLectureReviews(profSeq);
 
         return new ProfResponseDto(professorDto, lectureReviews);
@@ -62,17 +62,10 @@ public class ProfService {
                 ratingBreakdown.examDifficulty()) / 5.0;
     }
 
-    private ProfessorDto createProfessorDto(Professor professor, Double overallRating,
-            RatingBreakdownDto ratingBreakdown) {
-        return ProfessorDto.from(professor, overallRating, ratingBreakdown);
-    }
-
-
     private List<LectureReviewSummaryDto> getRecentLectureReviews(Long profSeq) {
         List<LectureReivew> recentLectureReviews = lectureReviewRepository
                 .findTop3ByLecture_Professor_ProfSeqOrderByCreatedDateDesc(profSeq)
                 .stream()
-                .limit(3)
                 .toList();
 
         return recentLectureReviews.stream()

--- a/src/main/java/com/kakao/uniscope/professor/service/ProfService.java
+++ b/src/main/java/com/kakao/uniscope/professor/service/ProfService.java
@@ -29,13 +29,13 @@ public class ProfService {
                 .orElseThrow(() -> new ProfessorNotFoundException(profSeq));
 
         // 교수 평가 통계
-        Double avgThesisPerf = FindAvg(() -> profReviewRepository.findAvgThesisPerf(profSeq));
-        Double avgResearchPerf = FindAvg(() -> profReviewRepository.findAvgResearchPerf(profSeq));
+        Double avgThesisPerf = findAvg(() -> profReviewRepository.findAvgThesisPerf(profSeq));
+        Double avgResearchPerf = findAvg(() -> profReviewRepository.findAvgResearchPerf(profSeq));
 
         // 강의 평가 통계
-        Double avgHomework = FindAvg(() -> lectureReviewRepository.findAvgHomework(profSeq));
-        Double avgLecDifficulty = FindAvg(() -> lectureReviewRepository.findAvgLecDifficulty(profSeq));
-        Double avgExamDifficulty = FindAvg(() -> lectureReviewRepository.findAvgExamDifficulty(profSeq));
+        Double avgHomework = findAvg(() -> lectureReviewRepository.findAvgHomework(profSeq));
+        Double avgLecDifficulty = findAvg(() -> lectureReviewRepository.findAvgLecDifficulty(profSeq));
+        Double avgExamDifficulty = findAvg(() -> lectureReviewRepository.findAvgExamDifficulty(profSeq));
 
         Double overallRating = (avgThesisPerf + avgResearchPerf +
                 avgHomework + avgLecDifficulty + avgExamDifficulty) / 5;
@@ -64,7 +64,7 @@ public class ProfService {
         return new ProfResponseDto(professorDto, lectureReviewDtos);
     }
 
-    private Double FindAvg(Supplier<Double> supplier) {
+    private Double findAvg(Supplier<Double> supplier) {
         try {
             Double result = supplier.get();
             return result != null ? result : 0.0;

--- a/src/main/java/com/kakao/uniscope/professor/service/ProfService.java
+++ b/src/main/java/com/kakao/uniscope/professor/service/ProfService.java
@@ -1,0 +1,75 @@
+package com.kakao.uniscope.professor.service;
+
+import com.kakao.uniscope.lecture.review.dto.LectureReviewSummaryDto;
+import com.kakao.uniscope.lecture.review.entity.LectureReivew;
+import com.kakao.uniscope.lecture.review.repository.LectureReviewRepository;
+import com.kakao.uniscope.professor.dto.ProfResponseDto;
+import com.kakao.uniscope.professor.dto.ProfessorDto;
+import com.kakao.uniscope.professor.dto.RatingBreakdownDto;
+import com.kakao.uniscope.professor.entity.Professor;
+import com.kakao.uniscope.professor.exception.ProfessorNotFoundException;
+import com.kakao.uniscope.professor.repository.ProfessorRepository;
+import com.kakao.uniscope.professor.review.repository.ProfReviewRepository;
+import java.util.List;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfService {
+
+    private final ProfessorRepository professorRepository;
+    private final LectureReviewRepository lectureReviewRepository;
+    private final ProfReviewRepository profReviewRepository;
+
+    public ProfResponseDto getProfessorDetails(Long profSeq) {
+
+        Professor professor = professorRepository.findById(profSeq)
+                .orElseThrow(() -> new ProfessorNotFoundException(profSeq));
+
+        // 교수 평가 통계
+        Double avgThesisPerf = FindAvg(() -> profReviewRepository.findAvgThesisPerf(profSeq));
+        Double avgResearchPerf = FindAvg(() -> profReviewRepository.findAvgResearchPerf(profSeq));
+
+        // 강의 평가 통계
+        Double avgHomework = FindAvg(() -> lectureReviewRepository.findAvgHomework(profSeq));
+        Double avgLecDifficulty = FindAvg(() -> lectureReviewRepository.findAvgLecDifficulty(profSeq));
+        Double avgExamDifficulty = FindAvg(() -> lectureReviewRepository.findAvgExamDifficulty(profSeq));
+
+        Double overallRating = (avgThesisPerf + avgResearchPerf +
+                avgHomework + avgLecDifficulty + avgExamDifficulty) / 5;
+
+        // 그래프에 평점 나타내기 위한 정보
+        RatingBreakdownDto ratingBreakdown = RatingBreakdownDto.of(
+                avgThesisPerf, avgResearchPerf,
+                avgHomework, avgLecDifficulty, avgExamDifficulty);
+
+        // 교수 dto 반환
+        ProfessorDto professorDto = ProfessorDto.from(
+                professor, overallRating, ratingBreakdown);
+
+        // 최근 강의평 3개
+        List<LectureReivew> recentLectureReviews = lectureReviewRepository
+                .findTop3ByLecture_Professor_ProfSeqOrderByCreatedDateDesc(profSeq)
+                .stream()
+                .limit(3)
+                .toList();
+
+        // 강의평 dto 반환
+        List<LectureReviewSummaryDto> lectureReviewDtos = recentLectureReviews.stream()
+                .map(LectureReviewSummaryDto::from)
+                .toList();
+
+        return new ProfResponseDto(professorDto, lectureReviewDtos);
+    }
+
+    private Double FindAvg(Supplier<Double> supplier) {
+        try {
+            Double result = supplier.get();
+            return result != null ? result : 0.0;
+        } catch (Exception e) {
+            return 0.0;
+        }
+    }
+}

--- a/src/test/java/com/kakao/uniscope/professor/controller/ProfController.java
+++ b/src/test/java/com/kakao/uniscope/professor/controller/ProfController.java
@@ -1,0 +1,43 @@
+package com.kakao.uniscope.professor.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kakao.uniscope.lecture.review.dto.LectureReviewSummaryDto;
+import com.kakao.uniscope.professor.dto.CollegeSimpleDto;
+import com.kakao.uniscope.professor.dto.ProfResponseDto;
+import com.kakao.uniscope.professor.dto.ProfessorDto;
+import com.kakao.uniscope.professor.dto.RatingBreakdownDto;
+import com.kakao.uniscope.professor.dto.UniversitySimpleDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+public class ProfController {
+
+    @Test
+    @DisplayName("Controller 응답 구조 검증 - 수동으로 Service 결과 확인")
+    void controllerResponseStructure() {
+        // given
+        var universityDto = new UniversitySimpleDto(1L, "충남대학교");
+        var collegeDto = new CollegeSimpleDto(1L, "공과대학");
+        var ratingBreakdown = new RatingBreakdownDto(4.0, 4.5, 3.5, 4.0, 3.8);
+        var professorDto = new ProfessorDto(1L, "김철수", universityDto, collegeDto,
+                "kimcs@cnu.ac.kr", 3.96, ratingBreakdown);
+
+        var lectureReview = new LectureReviewSummaryDto(1L, "자료구조", "2024-1",
+                3, 4, 3, 4, "N","좋은 강의", LocalDateTime.now());
+
+        var expectedResponse = new ProfResponseDto(professorDto, List.of(lectureReview));
+
+        // when
+        ResponseEntity<ProfResponseDto> response = ResponseEntity.ok(expectedResponse);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().professor().name()).isEqualTo("김철수");
+        assertThat(response.getBody().recentLectureReviews()).hasSize(1);
+    }
+}

--- a/src/test/java/com/kakao/uniscope/professor/service/ProfServiceTest.java
+++ b/src/test/java/com/kakao/uniscope/professor/service/ProfServiceTest.java
@@ -1,0 +1,53 @@
+package com.kakao.uniscope.professor.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kakao.uniscope.professor.dto.RatingBreakdownDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ProfServiceTest {
+
+    @Test
+    @DisplayName("전체 평점 계산 로직")
+    void calculateOverallRating_logic() {
+        // given
+        RatingBreakdownDto ratings = new RatingBreakdownDto(4.0, 4.5, 3.0, 3.5, 4.0);
+
+        // when
+        double overallRating = (ratings.thesisPerformance() +
+                ratings.researchPerformance() +
+                ratings.homework() +
+                ratings.lectureDifficulty() +
+                ratings.examDifficulty()) / 5.0;
+
+        // then
+        assertThat(overallRating).isEqualTo(3.8);
+    }
+
+    @Test
+    @DisplayName("RatingBreakdownDto 생성 로직")
+    void createRatingBreakdown() {
+        // given
+        Double thesis = 4.0;
+        Double research = 4.5;
+        Double homework = 3.0;
+        Double lecDifficulty = 3.5;
+        Double examDifficulty = 4.0;
+
+        // when
+        RatingBreakdownDto result = createRatingBreakdownDto(thesis, research, homework, lecDifficulty, examDifficulty);
+
+        // then
+        assertThat(result.thesisPerformance()).isEqualTo(4.0);
+        assertThat(result.researchPerformance()).isEqualTo(4.5);
+        assertThat(result.homework()).isEqualTo(3.0);
+        assertThat(result.lectureDifficulty()).isEqualTo(3.5);
+        assertThat(result.examDifficulty()).isEqualTo(4.0);
+    }
+
+    private RatingBreakdownDto createRatingBreakdownDto(Double thesis, Double research, Double homework,
+            Double lecDifficulty, Double examDifficulty) {
+        return RatingBreakdownDto.of(thesis, research, homework, lecDifficulty, examDifficulty);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #6 
- close: #15 

## 🚀 작업 내용

- dto: 응답값 반환을 위해 ProfessorDto, LectureReviewSummaryDto, ProfReviewSummaryDto, ProfResponseDto 등 구현
- Professor와 Lecture, Professor와 ProfReview, Lecture와 LectureReview 엔티티 간의 관계 설정
- ProfService에 getProfessorDetails() 비즈니스 로직 구현 (메서드 분리를 통한 리팩토링도 진행)
- 교수 기본 정보 조회, 교수 평가 통계 계산
- 최근 강의 리뷰 목록 조회 (최대 3개)
- ProfController에 GET /api/prof/{prof_seq} 엔드포인트 구현
- 컨트롤러와 서비스에 대한 테스트 코드 작성
- API 응답 형식이 명세와 일치하는지 확인

### 📸 스크린샷 (선택) 
#### 성공 응답
<img width="1874" height="1254" alt="image" src="https://github.com/user-attachments/assets/52b13cc0-facc-4cda-b4fd-6646bc06c76d" />

#### 실패 응답
<img width="1898" height="270" alt="image" src="https://github.com/user-attachments/assets/b692e9d1-7ffe-44bd-9460-a01b00b07239" />

## 📢 참고 사항

- DB의 기본 키 타입을 Long으로 통일

- 공동 코드(생성자, 수정자, 생성 일시 등)는 특정 필드를 제외하고 구현하지 않은 채로 개발했습니다.

- 교수 entity에서 학과와 매핑을 시켜야하는데 아직 학과 entity가 구현되지 않은 상태여서 일단 college(단과대학)과 매핑시켜놓음. (추후 수정해야함)

- 논문 평가에 대한 정보도 갖고와야하는데 추후 논문평가 추가 예정 (강의 리뷰와 같이 첫 화면에서는 3개만 조회되도록)
--> 강의 리뷰에 대한 전체 목록을 반환하는 api, 논문 평가에 대한 전체 목록을 반환하는 api 구현 예정