### PR TITLE
[Weekly 7] 단과 대학의 학과 목록 반환 API 구현

### DIFF
--- a/src/main/java/com/kakao/uniscope/college/controller/CollegeController.java
+++ b/src/main/java/com/kakao/uniscope/college/controller/CollegeController.java
@@ -1,0 +1,27 @@
+package com.kakao.uniscope.college.controller;
+
+import com.kakao.uniscope.college.dto.CollegeResponseDto;
+import com.kakao.uniscope.college.service.CollegeService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/college")
+public class CollegeController {
+
+    private final CollegeService collegeService;
+
+    public CollegeController(CollegeService collegeService) {
+        this.collegeService = collegeService;
+    }
+
+    @GetMapping("/{collegeSeq}")
+    public ResponseEntity<CollegeResponseDto> getDepartmentsByCollege(@PathVariable Long collegeSeq) {
+        CollegeResponseDto responseDto = collegeService.getDepartmentsByCollege(collegeSeq);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/college/dto/CollegeResponseDto.java
+++ b/src/main/java/com/kakao/uniscope/college/dto/CollegeResponseDto.java
@@ -1,0 +1,9 @@
+package com.kakao.uniscope.college.dto;
+
+import com.kakao.uniscope.department.dto.DepartmentDto;
+
+import java.util.List;
+
+public record CollegeResponseDto(
+        List<DepartmentDto> departments
+) { }

--- a/src/main/java/com/kakao/uniscope/college/entity/College.java
+++ b/src/main/java/com/kakao/uniscope/college/entity/College.java
@@ -3,7 +3,7 @@ package com.kakao.uniscope.college.entity;
 import com.kakao.uniscope.department.entity.Department;
 import com.kakao.uniscope.univ.entity.University;
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +11,9 @@ import java.util.List;
 @Entity
 @Table(name = "COLLEGE")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class College {
 
     @Id
@@ -26,7 +29,6 @@ public class College {
     private University university;
 
     @OneToMany(mappedBy = "college", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<Department> departments = new ArrayList<>();
-
-    protected College() {}
 }

--- a/src/main/java/com/kakao/uniscope/college/entity/College.java
+++ b/src/main/java/com/kakao/uniscope/college/entity/College.java
@@ -1,8 +1,12 @@
 package com.kakao.uniscope.college.entity;
 
+import com.kakao.uniscope.department.entity.Department;
 import com.kakao.uniscope.univ.entity.University;
 import jakarta.persistence.*;
 import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "COLLEGE")
@@ -20,6 +24,9 @@ public class College {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "UNIV_SEQ")
     private University university;
+
+    @OneToMany(mappedBy = "college", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Department> departments = new ArrayList<>();
 
     protected College() {}
 }

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeJpaRepository.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeJpaRepository.java
@@ -1,0 +1,17 @@
+package com.kakao.uniscope.college.repository;
+
+import com.kakao.uniscope.college.entity.College;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CollegeJpaRepository extends JpaRepository<College, Long> {
+    List<College> findByUniversity_UnivSeq(Long univSeq);
+
+    @EntityGraph(attributePaths = "departments")
+    Optional<College> findById(Long collegeSeq);
+}

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
@@ -1,17 +1,13 @@
 package com.kakao.uniscope.college.repository;
 
 import com.kakao.uniscope.college.entity.College;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-@Repository
-public interface CollegeRepository extends JpaRepository<College, Long> {
-    List<College> findByUniversity_UnivSeq(Long univSeq);
+public interface CollegeRepository {
 
-    @EntityGraph(attributePaths = "departments")
     Optional<College> findById(Long collegeSeq);
+
+    List<College> findByUniversitySeq(Long univSeq);
 }

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
@@ -1,12 +1,17 @@
 package com.kakao.uniscope.college.repository;
 
 import com.kakao.uniscope.college.entity.College;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CollegeRepository extends JpaRepository<College, Long> {
     List<College> findByUniversity_UnivSeq(Long univSeq);
+
+    @EntityGraph(attributePaths = "departments")
+    Optional<College> findById(Long collegeSeq);
 }

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeRepositoryImpl.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.kakao.uniscope.college.repository;
+
+import com.kakao.uniscope.college.entity.College;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CollegeRepositoryImpl implements CollegeRepository {
+
+    private final CollegeJpaRepository collegeJpaRepository;
+
+    @Override
+    public Optional<College> findById(Long collegeSeq) {
+        return collegeJpaRepository.findById(collegeSeq);
+    }
+
+    @Override
+    public List<College> findByUniversitySeq(Long univSeq) {
+        return collegeJpaRepository.findByUniversity_UnivSeq(univSeq);
+    }
+
+}

--- a/src/main/java/com/kakao/uniscope/college/service/CollegeService.java
+++ b/src/main/java/com/kakao/uniscope/college/service/CollegeService.java
@@ -1,0 +1,35 @@
+package com.kakao.uniscope.college.service;
+
+import com.kakao.uniscope.college.dto.CollegeResponseDto;
+import com.kakao.uniscope.college.entity.College;
+import com.kakao.uniscope.college.repository.CollegeRepository;
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
+import com.kakao.uniscope.department.dto.DepartmentDto;
+import com.kakao.uniscope.department.entity.Department;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CollegeService {
+
+    private final CollegeRepository collegeRepository;
+
+    public CollegeService(CollegeRepository collegeRepository) {
+        this.collegeRepository = collegeRepository;
+    }
+
+    public CollegeResponseDto getDepartmentsByCollege(Long collegeSeq) {
+        College college = collegeRepository.findById(collegeSeq)
+                .orElseThrow(() -> new ResourceNotFoundException(collegeSeq + "에 해당하는 단과대학을 찾을 수 없습니다."));
+
+        List<Department> departments = college.getDepartments();
+
+        List<DepartmentDto> departmentDtos = departments.stream()
+                .map(DepartmentDto::from)
+                .collect(Collectors.toList());
+
+        return new CollegeResponseDto(departmentDtos);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/college/service/CollegeService.java
+++ b/src/main/java/com/kakao/uniscope/college/service/CollegeService.java
@@ -5,11 +5,9 @@ import com.kakao.uniscope.college.entity.College;
 import com.kakao.uniscope.college.repository.CollegeRepository;
 import com.kakao.uniscope.common.exception.ResourceNotFoundException;
 import com.kakao.uniscope.department.dto.DepartmentDto;
-import com.kakao.uniscope.department.entity.Department;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class CollegeService {
@@ -24,11 +22,9 @@ public class CollegeService {
         College college = collegeRepository.findById(collegeSeq)
                 .orElseThrow(() -> new ResourceNotFoundException(collegeSeq + "에 해당하는 단과대학을 찾을 수 없습니다."));
 
-        List<Department> departments = college.getDepartments();
-
-        List<DepartmentDto> departmentDtos = departments.stream()
+        List<DepartmentDto> departmentDtos = college.getDepartments().stream()
                 .map(DepartmentDto::from)
-                .collect(Collectors.toList());
+                .toList();
 
         return new CollegeResponseDto(departmentDtos);
     }

--- a/src/main/java/com/kakao/uniscope/common/exception/ErrorResponse.java
+++ b/src/main/java/com/kakao/uniscope/common/exception/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.kakao.uniscope.common.exception;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorResponse {
+    private final int status;
+    private final String message;
+    private final LocalDateTime timestamp = LocalDateTime.now();
+
+    public ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/kakao/uniscope/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakao/uniscope/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.kakao.uniscope.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFoundException(ResourceNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/common/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/kakao/uniscope/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.kakao.uniscope.common.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/department/dto/DepartmentDto.java
+++ b/src/main/java/com/kakao/uniscope/department/dto/DepartmentDto.java
@@ -1,0 +1,17 @@
+package com.kakao.uniscope.department.dto;
+
+import com.kakao.uniscope.department.entity.Department;
+
+public record DepartmentDto(
+        Long deptSeq,
+        String deptName,
+        String homePage
+) {
+    public static DepartmentDto from(Department department) {
+        return new DepartmentDto(
+                department.getDeptSeq(),
+                department.getDeptName(),
+                department.getHomePage()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/department/entity/Department.java
+++ b/src/main/java/com/kakao/uniscope/department/entity/Department.java
@@ -2,14 +2,14 @@ package com.kakao.uniscope.department.entity;
 
 import com.kakao.uniscope.college.entity.College;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "DEPT")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Department {
 
     @Id

--- a/src/main/java/com/kakao/uniscope/department/entity/Department.java
+++ b/src/main/java/com/kakao/uniscope/department/entity/Department.java
@@ -1,0 +1,29 @@
+package com.kakao.uniscope.department.entity;
+
+import com.kakao.uniscope.college.entity.College;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "DEPT")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Department {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "DEPT_SEQ")
+    private Long deptSeq;
+
+    @Column(name = "DEPT_NAME")
+    private String deptName;
+
+    @Column(name = "HOME_PAGE")
+    private String homePage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "COLLEGE_SEQ")
+    private College college;
+}

--- a/src/main/java/com/kakao/uniscope/univ/entity/University.java
+++ b/src/main/java/com/kakao/uniscope/univ/entity/University.java
@@ -3,7 +3,7 @@ package com.kakao.uniscope.univ.entity;
 import com.kakao.uniscope.college.entity.College;
 import com.kakao.uniscope.univ.review.entity.UnivReview;
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +11,9 @@ import java.util.List;
 @Entity
 @Table(name = "UNIV")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class University {
 
     @Id
@@ -44,6 +47,4 @@ public class University {
 
     @OneToMany(mappedBy = "university", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UnivReview> reviews = new ArrayList<>();
-
-    protected University() {}
 }

--- a/src/main/java/com/kakao/uniscope/univ/repository/UnivJpaRepository.java
+++ b/src/main/java/com/kakao/uniscope/univ/repository/UnivJpaRepository.java
@@ -1,0 +1,15 @@
+package com.kakao.uniscope.univ.repository;
+
+import com.kakao.uniscope.univ.entity.University;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UnivJpaRepository extends JpaRepository<University, Long> {
+
+    @EntityGraph(attributePaths = {"colleges", "reviews"})
+    Optional<University> findById(Long univSeq);
+}

--- a/src/main/java/com/kakao/uniscope/univ/repository/UnivRepository.java
+++ b/src/main/java/com/kakao/uniscope/univ/repository/UnivRepository.java
@@ -1,8 +1,10 @@
 package com.kakao.uniscope.univ.repository;
 
 import com.kakao.uniscope.univ.entity.University;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
-public interface UnivRepository extends JpaRepository<University, Long> { }
+import java.util.Optional;
+
+public interface UnivRepository {
+
+    Optional<University> findById(Long univSeq);
+}

--- a/src/main/java/com/kakao/uniscope/univ/repository/UnivRepositoryImpl.java
+++ b/src/main/java/com/kakao/uniscope/univ/repository/UnivRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.kakao.uniscope.univ.repository;
+
+import com.kakao.uniscope.univ.entity.University;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UnivRepositoryImpl implements UnivRepository {
+
+    private final UnivJpaRepository univJpaRepository;
+
+    @Override
+    public Optional<University> findById(Long univSeq) {
+        return univJpaRepository.findById(univSeq);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/univ/review/entity/UnivReview.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/entity/UnivReview.java
@@ -2,13 +2,16 @@ package com.kakao.uniscope.univ.review.entity;
 
 import com.kakao.uniscope.univ.entity.University;
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "UNIV_REVIEW")
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UnivReview {
 
     @Id
@@ -43,6 +46,4 @@ public class UnivReview {
 
     @Column(name = "CREATE_DATE")
     private LocalDateTime createDate;
-
-    protected UnivReview() {}
 }

--- a/src/test/java/com/kakao/uniscope/college/CollegeControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/college/CollegeControllerTest.java
@@ -1,0 +1,62 @@
+package com.kakao.uniscope.college;
+
+import com.kakao.uniscope.college.controller.CollegeController;
+import com.kakao.uniscope.college.dto.CollegeResponseDto;
+import com.kakao.uniscope.college.service.CollegeService;
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
+import com.kakao.uniscope.department.dto.DepartmentDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CollegeController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
+public class CollegeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CollegeService collegeService;
+
+    @Test
+    @DisplayName("단과대학에 속한 학과 목록 조회 API 호출 성공")
+    void getDepartmentsByCollege_Success() throws Exception {
+
+        Long collegeSeq = 1L;
+        DepartmentDto mockDepartmentDto = new DepartmentDto(10L, "컴퓨터공학과", "http://cs.ac.kr");
+        CollegeResponseDto mockResponseDto = new CollegeResponseDto(List.of(mockDepartmentDto));
+
+        when(collegeService.getDepartmentsByCollege(collegeSeq)).thenReturn(mockResponseDto);
+
+        mockMvc.perform(get("/api/college/{collegeSeq}", collegeSeq)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(collegeService, times(1)).getDepartmentsByCollege(collegeSeq);
+    }
+
+    @Test
+    @DisplayName("단과대학에 속한 학과 목록 조회 실패 - 리소스 없음")
+    void getDepartmentsByCollege_NotFound() throws Exception {
+        Long collegeSeq = 999L;
+        when(collegeService.getDepartmentsByCollege(collegeSeq)).thenThrow(new ResourceNotFoundException(collegeSeq + "에 해당하는 단과대학을 찾을 수 없습니다."));
+
+        mockMvc.perform(get("/api/college/{collegeSeq}", collegeSeq)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+        verify(collegeService, times(1)).getDepartmentsByCollege(collegeSeq);
+    }
+}

--- a/src/test/java/com/kakao/uniscope/college/CollegeServiceTest.java
+++ b/src/test/java/com/kakao/uniscope/college/CollegeServiceTest.java
@@ -1,0 +1,45 @@
+package com.kakao.uniscope.college;
+
+import com.kakao.uniscope.college.dto.CollegeResponseDto;
+import com.kakao.uniscope.college.service.CollegeService;
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CollegeServiceTest {
+
+    private CollegeService collegeService;
+
+    @BeforeEach
+    void setUp() {
+        FakeCollegeRepository fakeRepository = new FakeCollegeRepository();
+        this.collegeService = new CollegeService(fakeRepository);
+    }
+
+    @Test
+    @DisplayName("존재하는 단과대학 seq로 학과 목록 조회 시, 학과 리스트가 정상 반환된다")
+    void getDepartmentsByCollege_Success() {
+        // given
+        Long collegeSeq = 1L;
+
+        // when
+        CollegeResponseDto result = collegeService.getDepartmentsByCollege(collegeSeq);
+
+        // then
+        assertNotNull(result);
+        assertEquals(2, result.departments().size());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 단과대학 seq 조회 시, ResourceNotFoundException 발생")
+    void getDepartmentsByCollege_NotFound() {
+        // given
+        Long collegeSeq = 999L;
+
+        // when & then
+        assertThrows(ResourceNotFoundException.class, () -> collegeService.getDepartmentsByCollege(collegeSeq));
+    }
+}

--- a/src/test/java/com/kakao/uniscope/college/FakeCollegeRepository.java
+++ b/src/test/java/com/kakao/uniscope/college/FakeCollegeRepository.java
@@ -1,0 +1,47 @@
+package com.kakao.uniscope.college;
+
+import com.kakao.uniscope.college.entity.College;
+import com.kakao.uniscope.college.repository.CollegeRepository;
+import com.kakao.uniscope.department.entity.Department;
+
+import java.util.*;
+
+public class FakeCollegeRepository implements CollegeRepository {
+
+    private final Map<Long, College> database = new HashMap<>();
+
+    public FakeCollegeRepository() {
+        // 더미 데이터 초기화
+        Department dept1 = Department.builder()
+                .deptSeq(1L)
+                .deptName("컴퓨터공학과")
+                .homePage("http://cs.ac.kr")
+                .build();
+
+        Department dept2 = Department.builder()
+                .deptSeq(2L)
+                .deptName("정보통신공학과")
+                .homePage("http://ice.ac.kr")
+                .build();
+
+        College college1 = College.builder()
+                .collegeSeq(1L)
+                .collegeName("공과대학")
+                .departments(List.of(dept1, dept2))
+                .build();
+
+        save(college1);
+    }
+
+    public void save(College college) {
+        database.put(college.getCollegeSeq(), college);
+    }
+
+    public Optional<College> findById(Long collegeSeq) {
+        return Optional.ofNullable(database.get(collegeSeq));
+    }
+
+    public List<College> findByUniversitySeq(Long univSeq) {
+        return new ArrayList<>(database.values());
+    }
+}

--- a/src/test/java/com/kakao/uniscope/univ/FakeUnivRepository.java
+++ b/src/test/java/com/kakao/uniscope/univ/FakeUnivRepository.java
@@ -1,0 +1,56 @@
+package com.kakao.uniscope.univ;
+
+import com.kakao.uniscope.college.entity.College;
+import com.kakao.uniscope.univ.entity.University;
+import com.kakao.uniscope.univ.repository.UnivRepository;
+import com.kakao.uniscope.univ.review.entity.UnivReview;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeUnivRepository implements UnivRepository {
+
+    private final Map<Long, University> database = new HashMap<>();
+
+    public FakeUnivRepository() {
+        // 더미 데이터 초기화
+        University univ1 = University.builder()
+                .univSeq(1L)
+                .name("충남대학교")
+                .colleges(List.of(
+                        College.builder().collegeSeq(1L).collegeName("공과대학").build(),
+                        College.builder().collegeSeq(2L).collegeName("자연과학대학").build()
+                ))
+                .reviews(List.of(
+                        UnivReview.builder().univReviewSeq(10L).overallScore(4).reviewText("리뷰1").createDate(LocalDateTime.now().minusDays(1)).build(),
+                        UnivReview.builder().univReviewSeq(11L).overallScore(5).reviewText("리뷰2").createDate(LocalDateTime.now()).build(),
+                        UnivReview.builder().univReviewSeq(12L).overallScore(3).reviewText("리뷰3").createDate(LocalDateTime.now().minusDays(2)).build()
+                ))
+                .build();
+
+        save(univ1);
+
+        University univ2 = University.builder()
+                .univSeq(2L)
+                .name("서울대학교")
+                .colleges(List.of(
+                        College.builder().collegeSeq(3L).collegeName("인문대학").build()
+                ))
+                .reviews(List.of())
+                .build();
+
+        save(univ2);
+    }
+
+    public void save(University university) {
+        database.put(university.getUnivSeq(), university);
+    }
+
+    @Override
+    public Optional<University> findById(Long univSeq) {
+        return Optional.ofNullable(database.get(univSeq));
+    }
+}

--- a/src/test/java/com/kakao/uniscope/univ/UnivServiceTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/UnivServiceTest.java
@@ -1,93 +1,66 @@
 package com.kakao.uniscope.univ;
 
-import com.kakao.uniscope.college.entity.College;
-import com.kakao.uniscope.college.repository.CollegeRepository;
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
 import com.kakao.uniscope.univ.dto.UnivResponseDto;
-import com.kakao.uniscope.univ.entity.University;
-import com.kakao.uniscope.univ.repository.UnivRepository;
-import com.kakao.uniscope.univ.review.entity.UnivReview;
-import com.kakao.uniscope.univ.review.repository.UnivReviewRepository;
+import com.kakao.uniscope.univ.review.dto.UnivReviewSummaryDto;
 import com.kakao.uniscope.univ.service.UnivService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.web.server.ResponseStatusException;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
 public class UnivServiceTest {
 
-    @Mock
-    private UnivRepository univRepository;
-
-    @Mock
-    private CollegeRepository collegeRepository;
-
-    @Mock
-    private UnivReviewRepository univReviewRepository;
-
-    @InjectMocks
     private UnivService univService;
 
-    @Test
-    @DisplayName("대학교 상세 정보 조회 성공")
-    void getUniversityDetails_Success() {
-        Long univSeq = 1L;
-
-        // 대학 엔티티
-        University mockUniv = mock(University.class);
-        when(mockUniv.getUnivSeq()).thenReturn(univSeq);
-        when(mockUniv.getName()).thenReturn("충남대학교");
-
-        // 단과 대학 엔티티
-        College mockCollege = mock(College.class);
-        when(mockCollege.getCollegeSeq()).thenReturn(1L);
-        when(mockCollege.getCollegeName()).thenReturn("공과대학");
-        List<College> mockColleges = List.of(mockCollege);
-
-        // 대학 평가 엔티티
-        UnivReview mockReview = mock(UnivReview.class);
-        when(mockReview.getUnivReviewSeq()).thenReturn(10L);
-        when(mockReview.getOverallScore()).thenReturn(4);
-        when(mockReview.getReviewText()).thenReturn("대학 리뷰");
-        when(mockReview.getCreateDate()).thenReturn(LocalDateTime.now());
-        List<UnivReview> mockReviews = List.of(mockReview);
-
-        when(univRepository.findById(univSeq)).thenReturn(Optional.of(mockUniv));
-        when(collegeRepository.findByUniversity_UnivSeq(univSeq)).thenReturn(mockColleges);
-        when(univReviewRepository.findTop3ByUniversityOrderByCreateDateDesc(any(University.class))).thenReturn(mockReviews);
-
-        UnivResponseDto result = univService.getUniversityDetails(univSeq);
-
-        // then: 결과 검증
-        assertNotNull(result);
-        assertEquals("충남대학교", result.university().name());
-        assertEquals(1, result.colleges().size());
-        assertEquals(1, result.univReviews().size());
-
-        // 리포지토리 메서드가 올바르게 호출되었는지 확인
-        verify(univRepository, times(1)).findById(univSeq);
-        verify(collegeRepository, times(1)).findByUniversity_UnivSeq(univSeq);
-        verify(univReviewRepository, times(1)).findTop3ByUniversityOrderByCreateDateDesc(any(University.class));
+    @BeforeEach
+    void setUp() {
+        FakeUnivRepository fakeUnivRepository = new FakeUnivRepository();
+        univService = new UnivService(fakeUnivRepository);
     }
 
     @Test
-    @DisplayName("대학교 상세 정보 조회 실패 - 리소스 없음")
-    void getUniversityDetails_NotFound() {
-        Long univSeq = 999L;
-        when(univRepository.findById(univSeq)).thenReturn(Optional.empty());
+    @DisplayName("대학교 상세 정보 조회 시, 기본 정보와 리스트가 정상 반환된다")
+    void getUniversityDetails_ReturnsDataSuccessfully() {
+        // given
+        Long univSeq = 1L;
 
-        assertThrows(ResponseStatusException.class, () -> univService.getUniversityDetails(univSeq));
-        verify(univRepository, times(1)).findById(univSeq);
+        // when
+        UnivResponseDto result = univService.getUniversityDetails(univSeq);
+
+        // then
+        assertNotNull(result);
+        assertEquals("충남대학교", result.university().name());
+        assertEquals(2, result.colleges().size());
+        assertEquals(3, result.univReviews().size());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 대학교 조회 시 ResourceNotFoundException 발생")
+    void getUniversityDetails_NotFound() {
+        assertThrows(ResourceNotFoundException.class,
+                () -> univService.getUniversityDetails(999L));
+    }
+
+    @Test
+    @DisplayName("리뷰는 최신순으로 정렬되어 반환된다")
+    void getUniversityDetails_ReviewsAreSortedByDate() {
+        // given
+        Long univSeq = 1L;
+
+        // when
+        UnivResponseDto result = univService.getUniversityDetails(univSeq);
+
+        // then
+        List<UnivReviewSummaryDto> reviews = result.univReviews();
+        for (int i = 0; i < reviews.size() - 1; i++) {
+            assertTrue(
+                    reviews.get(i).createDate().isAfter(reviews.get(i + 1).createDate())
+                            || reviews.get(i).createDate().isEqual(reviews.get(i + 1).createDate())
+            );
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #12 
- #4 

## 🚀 작업 내용

특정 단과 대학에 속한 학과 목록을 반환하는 API 구현

핵심 변경 사항은 다음과 같습니다.

- 엔티티 및 DTO 구현:
  - Department 엔티티 클래스와 CollegeResponseDto, DepartmentDto 등 API 응답에 필요한 DTO 클래스 구현

- Service 및 Controller 구현:
  - GET /api/college/{college_seq} 엔드포인트 구현

- Repository interface를 생성해 구현체가 Jpa Repository를 사용하도록 구현
  - 테스트 코드에서 fake repo를 만들어 주입해주기 위해 interface를 따로 만들고, 구현체를 두었습니다.

- 이전 PR에서 받았던 피드백들에 대한 변경 사항
  - UnivService에서 JPA 관계를 활용할 수 있도록 코드를 변경
  - 테스트 코드에서 불필요한 mocking을 없애고 단위 테스트를 수행할 수 있도록 리팩토링 진행

## 📢 참고 사항 (중점적으로 봐줬으면 하는 사항)

- 단위 테스트는 Mockito를 사용하지 않고, 엔티티 클래스에 빌더 패턴을 추가하고, FakeRepository를 직접 구현하여 구현

### 🖐🏼 RCA 룰

> r : 꼭 반영 해주세요 (request changes)
> c : 웬만하면 반영해주세요 (comment)
> a : 그냥 의견 혹은 칭찬(칭찬이 중요, 개발을 계속 하게 만드는 원동력이 될 수 있음) (approve)
