### PR TITLE
[Weekly 7] 사용자 인증 관리 API 구현 refactor

### DIFF
--- a/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
@@ -19,10 +19,6 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-    @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/users/signup", "/users/login").permitAll()
+                        .requestMatchers("/api/users/signup", "/api/users/login").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/kakao/uniscope/user/controller/UserController.java
+++ b/src/main/java/com/kakao/uniscope/user/controller/UserController.java
@@ -23,36 +23,16 @@ public class UserController {
     //회원가입
     @PostMapping("/signup")
     public ResponseEntity<CommonResponseDto<Void>> signup(@Valid @RequestBody UserSignupRequestDto requestDto) {
-        try {
-            userService.signup(requestDto);
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(CommonResponseDto.ok("회원가입이 완료되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.error("회원가입 실패: {}", e.getMessage());
-            return ResponseEntity.badRequest()
-                    .body(CommonResponseDto.error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("회원가입 중 오류 발생", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponseDto.error("서버 오류가 발생했습니다."));
-        }
+        userService.signup(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponseDto.ok("회원가입이 완료되었습니다."));
     }
 
     //로그인
     @PostMapping("/login")
     public ResponseEntity<CommonResponseDto<UserLoginResponseDto>> login(@Valid @RequestBody UserLoginRequestDto requestDto) {
-        try {
-            UserLoginResponseDto loginResponse = userService.login(requestDto);
-            return ResponseEntity.ok(CommonResponseDto.ok("로그인에 성공했습니다.", loginResponse));
-        } catch (IllegalArgumentException e) {
-            log.error("로그인 실패: {}", e.getMessage());
-            return ResponseEntity.badRequest()
-                    .body(CommonResponseDto.error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("로그인 중 오류 발생", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(CommonResponseDto.error("서버 오류가 발생했습니다."));
-        }
+        UserLoginResponseDto loginResponse = userService.login(requestDto);
+        return ResponseEntity.ok(CommonResponseDto.ok("로그인에 성공했습니다.", loginResponse));
     }
 
 }

--- a/src/main/java/com/kakao/uniscope/user/controller/UserController.java
+++ b/src/main/java/com/kakao/uniscope/user/controller/UserController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/src/main/java/com/kakao/uniscope/user/entity/User.java
+++ b/src/main/java/com/kakao/uniscope/user/entity/User.java
@@ -64,8 +64,8 @@ public class User {
             throw new IllegalArgumentException("암호화된 비밀번호는 필수입니다.");
         }
         
-        if (!isValidBCryptHash(encodedPassword)) {
-            throw new IllegalArgumentException("유효하지 않은 BCrypt 해시 형식입니다.");
+        if (!isValidEncodedPassword(encodedPassword)) {
+            throw new IllegalArgumentException("유효하지 않은 암호화된 비밀번호 형식입니다.");
         }
         
         // 기존 비밀번호와 동일한지 확인
@@ -76,11 +76,14 @@ public class User {
         this.userPwd = encodedPassword;
     }
     
-    // BCrypt 해시 형식 검증
-    private boolean isValidBCryptHash(String hash) {
-        return hash != null 
-            && hash.length() == 60 
-            && (hash.startsWith("$2a$") || hash.startsWith("$2b$") || hash.startsWith("$2y$"));
+    // 암호화된 비밀번호 형식 검증
+    private boolean isValidEncodedPassword(String encodedPassword) {
+        if (encodedPassword == null || encodedPassword.isBlank()) {
+            return false;
+        }
+        
+        return encodedPassword.length() == 60 
+            && (encodedPassword.startsWith("$2a$") || encodedPassword.startsWith("$2b$") || encodedPassword.startsWith("$2y$"));
     }
 
     public void softDelete() {

--- a/src/main/java/com/kakao/uniscope/user/entity/User.java
+++ b/src/main/java/com/kakao/uniscope/user/entity/User.java
@@ -58,8 +58,29 @@ public class User {
         this.deltYn = "N";
     }
 
-    public void updatePassword(String newPassword) {
-        this.userPwd = newPassword;
+    // 비밀번호 업데이트
+    public void updatePasswordWithEncoded(String encodedPassword) {
+        if (encodedPassword == null || encodedPassword.isBlank()) {
+            throw new IllegalArgumentException("암호화된 비밀번호는 필수입니다.");
+        }
+        
+        if (!isValidBCryptHash(encodedPassword)) {
+            throw new IllegalArgumentException("유효하지 않은 BCrypt 해시 형식입니다.");
+        }
+        
+        // 기존 비밀번호와 동일한지 확인
+        if (encodedPassword.equals(this.userPwd)) {
+            throw new IllegalArgumentException("새로운 비밀번호는 기존과 달라야 합니다.");
+        }
+        
+        this.userPwd = encodedPassword;
+    }
+    
+    // BCrypt 해시 형식 검증
+    private boolean isValidBCryptHash(String hash) {
+        return hash != null 
+            && hash.length() == 60 
+            && (hash.startsWith("$2a$") || hash.startsWith("$2b$") || hash.startsWith("$2y$"));
     }
 
     public void softDelete() {

--- a/src/main/java/com/kakao/uniscope/user/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakao/uniscope/user/exception/GlobalExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.kakao.uniscope.user.exception;
+
+import com.kakao.uniscope.user.dto.CommonResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 비즈니스 로직 예외 처리 (IllegalArgumentException)
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CommonResponseDto<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("비즈니스 로직 오류: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(CommonResponseDto.error(e.getMessage()));
+    }
+
+    /**
+     * 유효성 검증 예외 처리 (@Valid 실패)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponseDto<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse("유효성 검증에 실패했습니다.");
+        
+        log.error("유효성 검증 오류: {}", errorMessage);
+        return ResponseEntity.badRequest()
+                .body(CommonResponseDto.error(errorMessage));
+    }
+
+    /**
+     * 기타 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponseDto<Void>> handleException(Exception e) {
+        log.error("서버 오류 발생", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CommonResponseDto.error("서버 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/kakao/uniscope/user/service/UserService.java
+++ b/src/main/java/com/kakao/uniscope/user/service/UserService.java
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import com.kakao.uniscope.user.service.JwtTokenProvider;
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -92,5 +92,23 @@ public class UserService {
     //아이디 중복 체크
     public boolean existsByUserId(String userId) {
         return userRepository.existsByUserId(userId);
+    }
+
+    //비밀번호 변경
+    @Transactional
+    public void updatePassword(String userId, String currentPassword, String newPassword) {
+        // 사용자 조회
+        User user = findByUserId(userId);
+        
+        // 현재 비밀번호 확인
+        if (!passwordEncoder.matches(currentPassword, user.getUserPwd())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+        
+        String encodedNewPassword = passwordEncoder.encode(newPassword);
+        
+        user.updatePasswordWithEncoded(encodedNewPassword);
+        
+        log.info("비밀번호 변경 완료: userId={}", userId);
     }
 }

--- a/src/main/java/com/kakao/uniscope/user/service/UserService.java
+++ b/src/main/java/com/kakao/uniscope/user/service/UserService.java
@@ -7,7 +7,7 @@ import com.kakao.uniscope.user.entity.User;
 import com.kakao.uniscope.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.kakao.uniscope.user.service.JwtTokenProvider;
@@ -18,7 +18,7 @@ import com.kakao.uniscope.user.service.JwtTokenProvider;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final BCryptPasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
     //회원가입


### PR DESCRIPTION
## #️⃣연관된 이슈
>#8 [Feature] 사용자 인증 관리 API 구현

## 🚀 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 전역 예외 처리: @ControllerAdvice를 활용한 중앙화된 예외 처리
- API 엔드포인트 통일: /api/users prefix 추가로 API 명세서와 일치
- 비밀번호 암호화: BCrypt 기반 PasswordEncoder 설정


## 📢 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 전역 예외 처리에서 추가적인 예외 타입이 필요한지 의견 부탁드립니다
- 단위 테스트 및 통합 테스트는 이번 주에 mocking 없이 구현 예정입니다.
- Refresh Token 및 비밀번호 재설정 기능은 추후 구현 예정입니다.