### PR TITLE
[Weekly 8] 특정 교수의 정보 반환 api 개발 마무리

### DIFF
--- a/src/main/java/com/kakao/uniscope/lecture/entity/Lecture.java
+++ b/src/main/java/com/kakao/uniscope/lecture/entity/Lecture.java
@@ -28,7 +28,7 @@ public class Lecture {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "LEC_SEQ")
-    private Integer lecSeq;
+    private Long lecSeq;
 
     @Column(name = "LEC_NAME")
     private String lecName;

--- a/src/main/java/com/kakao/uniscope/lecture/review/repository/LectureReviewRepository.java
+++ b/src/main/java/com/kakao/uniscope/lecture/review/repository/LectureReviewRepository.java
@@ -2,6 +2,8 @@ package com.kakao.uniscope.lecture.review.repository;
 
 import com.kakao.uniscope.lecture.review.entity.LectureReivew;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +13,8 @@ import org.springframework.stereotype.Repository;
 public interface LectureReviewRepository extends JpaRepository<LectureReivew, Long> {
 
     List<LectureReivew> findTop3ByLecture_Professor_ProfSeqOrderByCreatedDateDesc(Long profSeq);
+
+    Page<LectureReivew> findByLecture_Professor_ProfSeqOrderByCreatedDateDesc(Long profSeq, Pageable pageable);
 
     // 과제량 평균
     @Query("SELECT AVG(lr.homework) FROM LectureReivew lr JOIN lr.lecture l WHERE l.professor.profSeq = :profSeq")
@@ -23,4 +27,13 @@ public interface LectureReviewRepository extends JpaRepository<LectureReivew, Lo
     // 시험 난이도 평균
     @Query("SELECT AVG(lr.examDifficulty) FROM LectureReivew lr JOIN lr.lecture l WHERE l.professor.profSeq = :profSeq")
     Double findAvgExamDifficulty(@Param("profSeq") Long profSeq);
+
+    // 교수별 전체 강의평 개수
+    @Query("SELECT COUNT(lr) FROM LectureReivew lr JOIN lr.lecture l WHERE l.professor.profSeq = :profSeq")
+    Integer countByProfessorId(@Param("profSeq") Long profSeq);
+
+    // 전체 강의평 평점 평균 (강의평 기준 전체 평점용)
+    @Query("SELECT AVG(CAST((lr.homework + lr.lecDifficulty + lr.examDifficulty) AS DOUBLE) / 3.0) " +
+            "FROM LectureReivew lr JOIN lr.lecture l WHERE l.professor.profSeq = :profSeq")
+    Double findOverallLectureRating(@Param("profSeq") Long profSeq);
 }

--- a/src/main/java/com/kakao/uniscope/lecture/review/repository/LectureReviewRepository.java
+++ b/src/main/java/com/kakao/uniscope/lecture/review/repository/LectureReviewRepository.java
@@ -36,4 +36,17 @@ public interface LectureReviewRepository extends JpaRepository<LectureReivew, Lo
     @Query("SELECT AVG(CAST((lr.homework + lr.lecDifficulty + lr.examDifficulty) AS DOUBLE) / 3.0) " +
             "FROM LectureReivew lr JOIN lr.lecture l WHERE l.professor.profSeq = :profSeq")
     Double findOverallLectureRating(@Param("profSeq") Long profSeq);
+
+    // 학과별 강의평 통계
+    @Query("SELECT AVG(lr.homework) FROM LectureReivew lr " +
+            "JOIN lr.lecture l JOIN l.professor p WHERE p.department.deptSeq = :deptSeq")
+    Double findDeptAvgHomework(@Param("deptSeq") Long deptSeq);
+
+    @Query("SELECT AVG(lr.lecDifficulty) FROM LectureReivew lr " +
+            "JOIN lr.lecture l JOIN l.professor p WHERE p.department.deptSeq = :deptSeq")
+    Double findDeptAvgLecDifficulty(@Param("deptSeq") Long deptSeq);
+
+    @Query("SELECT AVG(lr.examDifficulty) FROM LectureReivew lr " +
+            "JOIN lr.lecture l JOIN l.professor p WHERE p.department.deptSeq = :deptSeq")
+    Double findDeptAvgExamDifficulty(@Param("deptSeq") Long deptSeq);
 }

--- a/src/main/java/com/kakao/uniscope/professor/controller/ProfController.java
+++ b/src/main/java/com/kakao/uniscope/professor/controller/ProfController.java
@@ -1,8 +1,12 @@
 package com.kakao.uniscope.professor.controller;
 
+import com.kakao.uniscope.professor.dto.LectureReviewPageResponseDto;
 import com.kakao.uniscope.professor.dto.ProfResponseDto;
 import com.kakao.uniscope.professor.service.ProfService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +23,15 @@ public class ProfController {
     @GetMapping("/{prof_seq}")
     public ResponseEntity<ProfResponseDto> getProfessorDetails(@PathVariable("prof_seq") Long profSeq) {
         ProfResponseDto response = profService.getProfessorDetails(profSeq);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{prof_seq}/reviews")
+    public ResponseEntity<LectureReviewPageResponseDto> getProfessorLectureReviews(
+            @PathVariable("prof_seq") Long profSeq,
+            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        LectureReviewPageResponseDto response = profService.getProfessorLectureReviews(profSeq, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kakao/uniscope/professor/dto/DepartmentAverageDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/DepartmentAverageDto.java
@@ -1,0 +1,20 @@
+package com.kakao.uniscope.professor.dto;
+
+public record DepartmentAverageDto(
+        Double thesisPerformance,
+        Double researchPerformance,
+        Double homework,
+        Double lectureDifficulty,
+        Double examDifficulty
+) {
+    public static DepartmentAverageDto of(Double thesisPerf, Double researchPerf,
+            Double homework, Double lecDifficulty, Double examDifficulty) {
+        return new DepartmentAverageDto(
+                thesisPerf != null ? thesisPerf : 0.0,
+                researchPerf != null ? researchPerf : 0.0,
+                homework != null ? homework : 0.0,
+                lecDifficulty != null ? lecDifficulty : 0.0,
+                examDifficulty != null ? examDifficulty : 0.0
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/dto/DepartmentSimpleDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/DepartmentSimpleDto.java
@@ -1,0 +1,17 @@
+package com.kakao.uniscope.professor.dto;
+
+import com.kakao.uniscope.department.entity.Department;
+
+public record DepartmentSimpleDto(
+        Long id,
+        String name,
+        String homepage
+) {
+    public static DepartmentSimpleDto from(Department department) {
+        return new DepartmentSimpleDto(
+                department.getDeptSeq(),
+                department.getDeptName(),
+                department.getHomePage()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/dto/LectureReviewPageResponseDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/LectureReviewPageResponseDto.java
@@ -1,0 +1,18 @@
+package com.kakao.uniscope.professor.dto;
+
+import com.kakao.uniscope.lecture.review.dto.LectureReviewSummaryDto;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record LectureReviewPageResponseDto(
+        List<LectureReviewSummaryDto> reviews,
+        boolean hasNext
+) {
+    public static LectureReviewPageResponseDto from(Page<LectureReviewSummaryDto> page) {
+        return new LectureReviewPageResponseDto(
+                page.getContent(),
+                page.hasNext()
+        );
+    }
+
+}

--- a/src/main/java/com/kakao/uniscope/professor/dto/LectureSimpleDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/LectureSimpleDto.java
@@ -1,0 +1,23 @@
+package com.kakao.uniscope.professor.dto;
+
+import com.kakao.uniscope.lecture.entity.Lecture;
+
+public record LectureSimpleDto(
+        Long id,
+        String name,
+        String engLecYn,
+        String pnf,
+        String relYn,
+        Integer reviewCount
+) {
+    public static LectureSimpleDto from(Lecture lecture) {
+        return new LectureSimpleDto(
+                lecture.getLecSeq(),
+                lecture.getLecName(),
+                lecture.getEngLecYn(),
+                lecture.getPnf(),
+                lecture.getPnf(),
+                lecture.getLectureReviews().size()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/dto/ProfessorDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/ProfessorDto.java
@@ -16,11 +16,12 @@ public record ProfessorDto(
         String position,
         Double overallRating, // 강의평 기준 평점
         RatingBreakdownDto ratingBreakdown,
+        DepartmentAverageDto departmentAverage,
         List<LectureSimpleDto> lectures,
         Integer totalReviewCount
 ) {
     public static ProfessorDto from(Professor professor, Double overallRating, RatingBreakdownDto ratingBreakdown,
-            List<LectureSimpleDto> lectures, Integer totalReviewCount) {
+            DepartmentAverageDto departmentAverage, List<LectureSimpleDto> lectures, Integer totalReviewCount) {
         return new ProfessorDto(
                 professor.getProfSeq(),
                 professor.getProfName(),
@@ -33,6 +34,7 @@ public record ProfessorDto(
                 professor.getPosition(),
                 overallRating,
                 ratingBreakdown,
+                departmentAverage,
                 lectures,
                 totalReviewCount
         );

--- a/src/main/java/com/kakao/uniscope/professor/dto/ProfessorDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/ProfessorDto.java
@@ -2,25 +2,39 @@ package com.kakao.uniscope.professor.dto;
 
 
 import com.kakao.uniscope.professor.entity.Professor;
+import java.util.List;
 
 public record ProfessorDto(
         Long id,
         String name,
         UniversitySimpleDto university,
         CollegeSimpleDto college,
+        DepartmentSimpleDto department,
         String email,
-        Double overallRating,
-        RatingBreakdownDto ratingBreakdown
+        String imageUrl,
+        String office,
+        String position,
+        Double overallRating, // 강의평 기준 평점
+        RatingBreakdownDto ratingBreakdown,
+        List<LectureSimpleDto> lectures,
+        Integer totalReviewCount
 ) {
-    public static ProfessorDto from(Professor professor, Double overallRating, RatingBreakdownDto ratingBreakdown) {
+    public static ProfessorDto from(Professor professor, Double overallRating, RatingBreakdownDto ratingBreakdown,
+            List<LectureSimpleDto> lectures, Integer totalReviewCount) {
         return new ProfessorDto(
                 professor.getProfSeq(),
                 professor.getProfName(),
-                UniversitySimpleDto.from(professor.getCollege().getUniversity()),
-                CollegeSimpleDto.from(professor.getCollege()),
+                UniversitySimpleDto.from(professor.getDepartment().getCollege().getUniversity()),
+                CollegeSimpleDto.from(professor.getDepartment().getCollege()),
+                DepartmentSimpleDto.from(professor.getDepartment()),
                 professor.getProfEmail(),
+                professor.getImageUrl(),
+                professor.getOffice(),
+                professor.getPosition(),
                 overallRating,
-                ratingBreakdown
+                ratingBreakdown,
+                lectures,
+                totalReviewCount
         );
     }
 }

--- a/src/main/java/com/kakao/uniscope/professor/entity/Professor.java
+++ b/src/main/java/com/kakao/uniscope/professor/entity/Professor.java
@@ -1,6 +1,6 @@
 package com.kakao.uniscope.professor.entity;
 
-import com.kakao.uniscope.college.entity.College;
+import com.kakao.uniscope.department.entity.Department;
 import com.kakao.uniscope.lecture.entity.Lecture;
 import com.kakao.uniscope.professor.review.entity.ProfReview;
 import jakarta.persistence.CascadeType;
@@ -40,10 +40,18 @@ public class Professor {
     @Column(name = "HOME_PAGE")
     private String homePage;
 
-    // todo: 추후 college를 department(학과)와 연관관계 매핑해야함 -> profdto수정도 필요
+    @Column(name = "OFFICE")
+    private String office; // 사무실 정보(공5601)
+
+    @Column(name = "POSITION")
+    private String position; // 교수 직책 (교수, 조교수, 명예교수 등)
+
+    @Column(name = "IMAGE_URL")
+    private String imageUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "COLLEGE_SEQ")  // DB에서 이 컬럼으로 College와 연결
-    private College college;
+    @JoinColumn(name = "DEPT_SEQ")
+    private Department department;
 
     @OneToMany(mappedBy = "professor", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Lecture> lectures = new ArrayList<>();

--- a/src/main/java/com/kakao/uniscope/professor/review/repository/ProfReviewRepository.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/repository/ProfReviewRepository.java
@@ -16,4 +16,13 @@ public interface ProfReviewRepository extends JpaRepository<ProfReview, Long> {
     // 연구 실적 평균
     @Query("SELECT AVG(pr.researchPerf) FROM ProfReview pr WHERE pr.professor.profSeq = :profSeq")
     Double findAvgResearchPerf(@Param("profSeq") Long profSeq);
+
+    // 학과별 교수평가 통계
+    @Query("SELECT AVG(pr.thesisPerf) FROM ProfReview pr " +
+            "JOIN pr.professor p WHERE p.department.deptSeq = :deptSeq")
+    Double findDeptAvgThesisPerf(@Param("deptSeq") Long deptSeq);
+
+    @Query("SELECT AVG(pr.researchPerf) FROM ProfReview pr " +
+            "JOIN pr.professor p WHERE p.department.deptSeq = :deptSeq")
+    Double findDeptAvgResearchPerf(@Param("deptSeq") Long deptSeq);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #14 
- #29 

- close: #[issue number]

## 🚀 작업 내용

- 교수의 필드에 사무실(office) 컬럼 추가
- 교수의 필드에 교수, 조교수, 명예교수 구분(position)  컬럼 추가
- 교수 이미지(image_url) 컬럼 추가
- 교수의 개설 강의 전체 목록 반환 api 추가
- 강의평가 개수 반환 하는 쿼리 작성
- 전체 평점을 강의평가 기준으로만 계산
- 최근 강의평전체를 가져올때 별도 API로 분리하여 페이징 처리

### 📸 스크린샷 (선택) 
- 교수의 기본정보 및 평균 평점과 학과 교수 평균 평점
<img width="922" height="946" alt="image" src="https://github.com/user-attachments/assets/978ff9aa-b91c-477b-a43b-c6f43ee6bfea" />

- 교수의 전체 강의 가져오기
<img width="551" height="733" alt="image" src="https://github.com/user-attachments/assets/7878b1a4-2b86-48fc-a48a-9eeb53282e7e" />

- 최근 강의평 3개 가져오기
<img width="1069" height="1018" alt="image" src="https://github.com/user-attachments/assets/ff427398-c17d-41a3-87de-3b061e908637" />

- 모든 강의를 가져올때 페이징 처리
<img width="1878" height="1256" alt="image" src="https://github.com/user-attachments/assets/71ec2e83-823a-4aef-83f7-bef50d8570f1" />

## 📢 참고 사항

교수 평가 사항은 추후 개발 예정