### PR TITLE
[Weekly 9] 학과의 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/kakao/uniscope/college/dto/CollegeDetailsResponseDto.java
+++ b/src/main/java/com/kakao/uniscope/college/dto/CollegeDetailsResponseDto.java
@@ -9,7 +9,8 @@ public record CollegeDetailsResponseDto(
         String collegeEstablishedYear,
         String collegeTel,
         String collegeHomePage,
-        String collegeIntro
+        String collegeIntro,
+        Integer professorCount
 ) {
     public static CollegeDetailsResponseDto from(College college) {
         return new CollegeDetailsResponseDto(
@@ -19,7 +20,8 @@ public record CollegeDetailsResponseDto(
                 college.getCollegeEstablishedYear(),
                 college.getCollegeTel(),
                 college.getCollegeHomePage(),
-                college.getCollegeIntro()
+                college.getCollegeIntro(),
+                college.getProfessorCount()
         );
     }
 }

--- a/src/main/java/com/kakao/uniscope/college/entity/College.java
+++ b/src/main/java/com/kakao/uniscope/college/entity/College.java
@@ -46,4 +46,14 @@ public class College {
     @OneToMany(mappedBy = "college", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Department> departments = new ArrayList<>();
+
+    public int getProfessorCount() {
+        if (this.departments == null) {
+            return 0;
+        }
+
+        return this.departments.stream()
+                .mapToInt(department -> department.getProfessors() != null ? department.getProfessors().size() : 0)
+                .sum();
+    }
 }

--- a/src/main/java/com/kakao/uniscope/department/careerField/dto/CareerFieldDto.java
+++ b/src/main/java/com/kakao/uniscope/department/careerField/dto/CareerFieldDto.java
@@ -1,0 +1,15 @@
+package com.kakao.uniscope.department.careerField.dto;
+
+import com.kakao.uniscope.department.careerField.entity.CareerField;
+
+public record CareerFieldDto(
+        Long careerFieldSeq,
+        String fieldName
+) {
+    public static CareerFieldDto from(CareerField careerField) {
+        return new CareerFieldDto(
+                careerField.getCareerFieldSeq(),
+                careerField.getFieldName()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/department/careerField/entity/CareerField.java
+++ b/src/main/java/com/kakao/uniscope/department/careerField/entity/CareerField.java
@@ -1,0 +1,28 @@
+package com.kakao.uniscope.department.careerField.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "CAREER_FIELD")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CareerField {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CAREER_FIELD_SEQ")
+    private Long careerFieldSeq;
+
+    @Column(name = "FIELD_NAME", length = 100, unique = true)
+    private String fieldName;
+
+    @OneToMany(mappedBy = "careerField", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private Set<DepartmentCareerField> departmentCareerFields = new HashSet<>();
+}

--- a/src/main/java/com/kakao/uniscope/department/careerField/entity/DepartmentCareerField.java
+++ b/src/main/java/com/kakao/uniscope/department/careerField/entity/DepartmentCareerField.java
@@ -1,0 +1,29 @@
+package com.kakao.uniscope.department.careerField.entity;
+
+import com.kakao.uniscope.department.entity.Department;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Entity
+@Table(name = "DEPT_CAREER_FIELD")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class DepartmentCareerField implements Serializable {
+
+    @EmbeddedId
+    private DepartmentCareerFieldId id;
+
+    @MapsId("deptSeq")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "DEPT_SEQ")
+    private Department department;
+
+    @MapsId("fieldSeq")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "FIELD_SEQ")
+    private CareerField careerField;
+}

--- a/src/main/java/com/kakao/uniscope/department/careerField/entity/DepartmentCareerFieldId.java
+++ b/src/main/java/com/kakao/uniscope/department/careerField/entity/DepartmentCareerFieldId.java
@@ -1,0 +1,19 @@
+package com.kakao.uniscope.department.careerField.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class DepartmentCareerFieldId implements Serializable {
+    private Long deptSeq;
+    private Long fieldSeq;
+}

--- a/src/main/java/com/kakao/uniscope/department/controller/DepartmentController.java
+++ b/src/main/java/com/kakao/uniscope/department/controller/DepartmentController.java
@@ -1,0 +1,27 @@
+package com.kakao.uniscope.department.controller;
+
+import com.kakao.uniscope.department.dto.DepartmentInfoResponse;
+import com.kakao.uniscope.department.service.DepartmentService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/departments")
+public class DepartmentController {
+
+    private final DepartmentService departmentService;
+
+    public DepartmentController(DepartmentService departmentService) {
+        this.departmentService = departmentService;
+    }
+
+    @GetMapping("/{deptSeq}")
+    public ResponseEntity<DepartmentInfoResponse> getDeptDetails(@PathVariable Long deptSeq) {
+        DepartmentInfoResponse response = departmentService.getDeptDetails(deptSeq);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
+++ b/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
@@ -1,0 +1,42 @@
+package com.kakao.uniscope.department.dto;
+
+import com.kakao.uniscope.department.careerField.dto.CareerFieldDto;
+import com.kakao.uniscope.department.careerField.entity.DepartmentCareerField;
+import com.kakao.uniscope.department.entity.Department;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record DepartmentInfoResponse(
+        Long deptSeq,
+        String deptName,
+        String homePage,
+        String deptAddress,
+        String deptTel,
+        String deptEmail,
+        String deptEstablishedYear,
+        String deptIntro,
+        Integer deptStudentNum,
+        Set<CareerFieldDto> careerFields
+) {
+    public static DepartmentInfoResponse from(Department department) {
+
+        Set<CareerFieldDto> careerFieldDtos = department.getDepartmentCareerFields().stream()
+                .map(DepartmentCareerField::getCareerField)
+                .map(CareerFieldDto::from)
+                .collect(Collectors.toSet());
+
+        return new DepartmentInfoResponse(
+                department.getDeptSeq(),
+                department.getDeptName(),
+                department.getHomePage(),
+                department.getDeptAddress(),
+                department.getDeptTel(),
+                department.getDeptEmail(),
+                department.getDeptEstablishedYear(),
+                department.getDeptIntro(),
+                department.getDeptStudentNum(),
+                careerFieldDtos
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
+++ b/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
@@ -17,6 +17,7 @@ public record DepartmentInfoResponse(
         String deptEstablishedYear,
         String deptIntro,
         Integer deptStudentNum,
+        Integer professorCount,
         Set<CareerFieldDto> careerFields
 ) {
     public static DepartmentInfoResponse from(Department department) {
@@ -25,6 +26,8 @@ public record DepartmentInfoResponse(
                 .map(DepartmentCareerField::getCareerField)
                 .map(CareerFieldDto::from)
                 .collect(Collectors.toSet());
+
+        int professorCount = department.getProfessors() != null ? department.getProfessorCount() : 0;
 
         return new DepartmentInfoResponse(
                 department.getDeptSeq(),
@@ -36,6 +39,7 @@ public record DepartmentInfoResponse(
                 department.getDeptEstablishedYear(),
                 department.getDeptIntro(),
                 department.getDeptStudentNum(),
+                professorCount,
                 careerFieldDtos
         );
     }

--- a/src/main/java/com/kakao/uniscope/department/entity/Department.java
+++ b/src/main/java/com/kakao/uniscope/department/entity/Department.java
@@ -59,4 +59,8 @@ public class Department {
     @OneToMany(mappedBy = "department", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private Set<DepartmentCareerField> departmentCareerFields = new HashSet<>();
+
+    public int getProfessorCount() {
+        return this.professors.size();
+    }
 }

--- a/src/main/java/com/kakao/uniscope/department/entity/Department.java
+++ b/src/main/java/com/kakao/uniscope/department/entity/Department.java
@@ -1,12 +1,15 @@
 package com.kakao.uniscope.department.entity;
 
 import com.kakao.uniscope.college.entity.College;
+import com.kakao.uniscope.department.careerField.entity.DepartmentCareerField;
 import com.kakao.uniscope.professor.entity.Professor;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = "DEPT")
@@ -42,11 +45,18 @@ public class Department {
     @Column(name = "DEPT_INTRO")
     private String deptIntro;
 
+    @Column(name = "DEPT_STUDENT_NUM")
+    private Integer deptStudentNum;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "COLLEGE_SEQ")
     private College college;
 
-     @OneToMany(mappedBy = "department", cascade = CascadeType.ALL, orphanRemoval = true)
-     @Builder.Default
-     private List<Professor> professors = new ArrayList<>();
+    @OneToMany(mappedBy = "department", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Professor> professors = new ArrayList<>();
+
+    @OneToMany(mappedBy = "department", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private Set<DepartmentCareerField> departmentCareerFields = new HashSet<>();
 }

--- a/src/main/java/com/kakao/uniscope/department/repository/DepartmentJpaRepository.java
+++ b/src/main/java/com/kakao/uniscope/department/repository/DepartmentJpaRepository.java
@@ -1,0 +1,15 @@
+package com.kakao.uniscope.department.repository;
+
+import com.kakao.uniscope.department.entity.Department;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface DepartmentJpaRepository extends JpaRepository<Department, Long> {
+
+    @EntityGraph(attributePaths = {"professors", "departmentCareerFields"})
+    Optional<Department> findWithFullDetailsByDeptSeq(Long deptSeq);
+}

--- a/src/main/java/com/kakao/uniscope/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/kakao/uniscope/department/repository/DepartmentRepository.java
@@ -1,0 +1,11 @@
+package com.kakao.uniscope.department.repository;
+
+import com.kakao.uniscope.department.entity.Department;
+
+import java.util.Optional;
+
+public interface DepartmentRepository {
+
+    // deptSeq를 통해 학과의 상세 정보를 조회
+    Optional<Department> findWithFullDetailsByDeptSeq(Long deptSeq);
+}

--- a/src/main/java/com/kakao/uniscope/department/repository/DepartmentRepositoryImpl.java
+++ b/src/main/java/com/kakao/uniscope/department/repository/DepartmentRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.kakao.uniscope.department.repository;
+
+import com.kakao.uniscope.department.entity.Department;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class DepartmentRepositoryImpl implements DepartmentRepository {
+
+    private final DepartmentJpaRepository departmentJpaRepository;
+
+    public DepartmentRepositoryImpl(DepartmentJpaRepository departmentJpaRepository) {
+        this.departmentJpaRepository = departmentJpaRepository;
+    }
+
+    @Override
+    public Optional<Department> findWithFullDetailsByDeptSeq(Long deptSeq) {
+        return departmentJpaRepository.findWithFullDetailsByDeptSeq(deptSeq);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/department/service/DepartmentService.java
+++ b/src/main/java/com/kakao/uniscope/department/service/DepartmentService.java
@@ -1,0 +1,26 @@
+package com.kakao.uniscope.department.service;
+
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
+import com.kakao.uniscope.department.dto.DepartmentInfoResponse;
+import com.kakao.uniscope.department.entity.Department;
+import com.kakao.uniscope.department.repository.DepartmentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly=true)
+public class DepartmentService {
+
+    private final DepartmentRepository departmentRepository;
+
+    public DepartmentService(DepartmentRepository departmentRepository) {
+        this.departmentRepository = departmentRepository;
+    }
+
+    public DepartmentInfoResponse getDeptDetails(Long deptSeq) {
+        Department department = departmentRepository.findWithFullDetailsByDeptSeq(deptSeq)
+                .orElseThrow(() -> new ResourceNotFoundException(deptSeq + "에 해당하는 학과를 찾을 수 없습니다."));
+
+        return DepartmentInfoResponse.from(department);
+    }
+}

--- a/src/test/java/com/kakao/uniscope/college/CollegeControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/college/CollegeControllerTest.java
@@ -64,7 +64,7 @@ public class CollegeControllerTest {
     @Test
     void 단과대학의_정보_반환_API_동작_성공()  throws Exception {
         Long collegeSeq = 1L;
-        CollegeDetailsResponseDto mockResponseDto = new CollegeDetailsResponseDto(1L, null, null, null, null, null, null);
+        CollegeDetailsResponseDto mockResponseDto = new CollegeDetailsResponseDto(1L, null, null, null, null, null, null, 1);
 
         when(collegeService.getCollegeDetails(collegeSeq)).thenReturn(mockResponseDto);
 

--- a/src/test/java/com/kakao/uniscope/department/DepartmentControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/department/DepartmentControllerTest.java
@@ -1,0 +1,55 @@
+package com.kakao.uniscope.department;
+
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
+import com.kakao.uniscope.department.controller.DepartmentController;
+import com.kakao.uniscope.department.dto.DepartmentInfoResponse;
+import com.kakao.uniscope.department.service.DepartmentService;
+import com.kakao.uniscope.univ.controller.UnivController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = DepartmentController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
+public class DepartmentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DepartmentService departmentService;
+
+    @Test
+    void 학과_상세_정보_조회_API_동작_성공() throws Exception {
+        Long deptSeq = 1L;
+
+        DepartmentInfoResponse mockResponse = new DepartmentInfoResponse(1L, "", "", "", "", "", "", "", 0, null, null);
+
+        when(departmentService.getDeptDetails(deptSeq)).thenReturn(mockResponse);
+
+        mockMvc.perform(get("/api/departments/{deptSeq}", deptSeq))
+                .andExpect(status().isOk());
+
+        verify(departmentService, times(1)).getDeptDetails(deptSeq);
+    }
+
+    @Test
+    void 학과_상세_정보_조회_API_동작_실패()  throws Exception {
+        Long deptSeq = 999L;
+
+        when(departmentService.getDeptDetails(deptSeq))
+                .thenThrow(new ResourceNotFoundException(deptSeq + "에 해당하는 학과를 찾을 수 없습니다."));
+
+        mockMvc.perform(get("/api/departments/{deptSeq}", deptSeq))
+                .andExpect(status().isNotFound());
+
+        verify(departmentService, times(1)).getDeptDetails(deptSeq);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #44 

## 🚀 작업 내용 (변경 사항)

- 기존 Department 엔티티에서 필드 추가
  - 학과 재학생 수

- 학과 엔티티가 가지는 취업/진로 분야 다대다 관계를 위해 엔티티 구조 추가
  - CareerField, DepartmentCareerField, DepartmentCareerFieldId(Serializable)
  - 학과-진로 간 다대다 관계를 구현

- API 관련 컨트롤러, 서비스, 리포지토리 레이어 구현

- College, Department 엔티티에 교수 수를 반환하는 메서드 추가
  - dto, 테스트 코드 변경

- 학과 정보 조회 테스트 코드 작성

### 📸 스크린샷

## 📢 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> r : 꼭 반영 해주세요 (request changes)
> c : 웬만하면 반영해주세요 (comment)
> a : 그냥 의견 혹은 칭찬(칭찬이 중요, 개발을 계속 하게 만드는 원동력이 될 수 있음) (approve)

다대다 관계를 연관관계의 중간 테이블을 통해 해결하려고 했습니다.
중간 엔티티인 DepartmentCareerField를 만들고, 복합 키를 `@EmbeddedId`를 사용하여 관리하는 방식을 사용했습니다.

`@ElementCollection`의 사용도 고려해봤는데, 추가 속성이 없는 단순 값 타입 컬렉션을 저장할 때는 사용해도 되는지 궁금합니다.