### PR TITLE
{Weekly 9] 대학 리뷰 작성 API 구현

### DIFF
--- a/src/main/java/com/kakao/uniscope/univ/review/controller/UnivReviewController.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/controller/UnivReviewController.java
@@ -1,0 +1,33 @@
+package com.kakao.uniscope.univ.review.controller;
+
+import com.kakao.uniscope.univ.review.dto.ReviewCreateResponse;
+import com.kakao.uniscope.univ.review.dto.UnivReviewRequest;
+import com.kakao.uniscope.univ.review.service.UnivReviewService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reviews/univ")
+public class UnivReviewController {
+
+    private final UnivReviewService univReviewService;
+
+    public UnivReviewController(UnivReviewService univReviewService) {
+        this.univReviewService = univReviewService;
+    }
+
+    // 대학 평가 작성 API
+    @PostMapping
+    public ResponseEntity<ReviewCreateResponse> createUnivReview(
+            @Valid @RequestBody UnivReviewRequest request
+    ) {
+        ReviewCreateResponse response = univReviewService.createReview(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/univ/review/dto/ReviewCreateResponse.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/dto/ReviewCreateResponse.java
@@ -1,0 +1,18 @@
+package com.kakao.uniscope.univ.review.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record ReviewCreateResponse(
+        Long reviewSeq,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime timestamp
+) {
+    public static ReviewCreateResponse of(Long reviewSeq) {
+        return new ReviewCreateResponse(
+                reviewSeq,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewDto.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewDto.java
@@ -13,7 +13,6 @@ public record UnivReviewDto(
         Integer campusScore,
         Integer overallScore,
         String reviewText,
-        String createUser,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime createDate
 ) {
@@ -26,7 +25,6 @@ public record UnivReviewDto(
                 univReview.getCampusScore(),
                 univReview.getOverallScore(),
                 univReview.getReviewText(),
-                univReview.getCreateUser(),
                 univReview.getCreateDate()
         );
     }

--- a/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewRequest.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewRequest.java
@@ -1,0 +1,32 @@
+package com.kakao.uniscope.univ.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record UnivReviewRequest(
+        @NotNull(message = "대학 고유 번호는 필수입니다.")
+        Long univSeq,
+
+        @NotNull(message = "학식 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer food,
+
+        @NotNull(message = "기숙사 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer dormitory,
+
+        @NotNull(message = "편의시설 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer convenience,
+
+        @NotNull(message = "캠퍼스 환경 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer campus,
+
+        @NotNull(message = "전반적인 만족도 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer overall,
+
+        String reviewText
+) { }

--- a/src/main/java/com/kakao/uniscope/univ/review/entity/UnivReview.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/entity/UnivReview.java
@@ -41,9 +41,6 @@ public class UnivReview {
     @Column(name = "REVIEW_TXT")
     private String reviewText;
 
-    @Column(name = "CREATE_USER")
-    private String createUser;
-
     @Column(name = "CREATE_DATE")
     private LocalDateTime createDate;
 }

--- a/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepository.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface UnivReviewRepository {
     Page<UnivReview> findByUniversity(University university, Pageable pageable);
+
+    UnivReview save(UnivReview univReview);
 }

--- a/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepositoryImpl.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepositoryImpl.java
@@ -19,4 +19,9 @@ public class UnivReviewRepositoryImpl implements UnivReviewRepository {
     public Page<UnivReview> findByUniversity(University university, Pageable pageable) {
         return univReviewJpaRepository.findByUniversity(university, pageable);
     }
+
+    @Override
+    public UnivReview save(UnivReview univReview) {
+        return univReviewJpaRepository.save(univReview);
+    }
 }

--- a/src/main/java/com/kakao/uniscope/univ/review/service/UnivReviewService.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/service/UnivReviewService.java
@@ -3,7 +3,9 @@ package com.kakao.uniscope.univ.review.service;
 import com.kakao.uniscope.common.exception.ResourceNotFoundException;
 import com.kakao.uniscope.univ.entity.University;
 import com.kakao.uniscope.univ.repository.UnivRepository;
+import com.kakao.uniscope.univ.review.dto.ReviewCreateResponse;
 import com.kakao.uniscope.univ.review.dto.UnivReviewDto;
+import com.kakao.uniscope.univ.review.dto.UnivReviewRequest;
 import com.kakao.uniscope.univ.review.dto.UnivReviewResponseDto;
 import com.kakao.uniscope.univ.review.entity.UnivReview;
 import com.kakao.uniscope.univ.review.repository.UnivReviewRepository;
@@ -12,7 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
+@Transactional(readOnly = true)
 public class UnivReviewService {
 
     private final UnivRepository univRepository;
@@ -23,7 +28,6 @@ public class UnivReviewService {
         this.univReviewRepository = univReviewRepository;
     }
 
-    @Transactional(readOnly = true)
     public UnivReviewResponseDto getAllUnivReviews(Long univSeq, Pageable pageable) {
         University university = univRepository.findById(univSeq)
                 .orElseThrow(() -> new ResourceNotFoundException(univSeq + "에 해당하는 대학교를 찾을 수 없습니다."));
@@ -33,5 +37,26 @@ public class UnivReviewService {
         Page<UnivReviewDto> reviewDtoPage = reviewPage.map(UnivReviewDto::from);
 
         return UnivReviewResponseDto.from(reviewDtoPage);
+    }
+
+    @Transactional(readOnly = false)
+    public ReviewCreateResponse createReview(UnivReviewRequest request) {
+        University university = univRepository.findById(request.univSeq())
+                .orElseThrow(() -> new ResourceNotFoundException(request.univSeq() + "에 해당하는 대학교를 찾을 수 없습니다."));
+
+        UnivReview newReview = UnivReview.builder()
+                .university(university)
+                .foodScore(request.food())
+                .dormScore(request.dormitory())
+                .convScore(request.convenience())
+                .campusScore(request.campus())
+                .overallScore(request.overall())
+                .reviewText(request.reviewText())
+                .createDate(LocalDateTime.now())
+                .build();
+
+        UnivReview savedReview = univReviewRepository.save(newReview);
+
+        return ReviewCreateResponse.of(savedReview.getUnivReviewSeq());
     }
 }

--- a/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,10 +31,13 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
+                .headers(header-> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
                         .requestMatchers("/api/users/signup", "/api/users/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/reviews/univ").permitAll() // 대학 리뷰 작성은 허용
+                        .requestMatchers("/h2-console/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/test/java/com/kakao/uniscope/univ/univReview/FakeUnivReviewRepository.java
+++ b/src/test/java/com/kakao/uniscope/univ/univReview/FakeUnivReviewRepository.java
@@ -7,21 +7,26 @@ import com.kakao.uniscope.univ.review.repository.UnivReviewRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 public class FakeUnivReviewRepository implements UnivReviewRepository {
 
     private final List<UnivReview> reviews;
 
+    private final AtomicLong sequenceGenerator = new  AtomicLong(0);
+
     public FakeUnivReviewRepository() {
         University univ1 = TestObjectFactory.createUniv1();
         University univ2 = TestObjectFactory.createUniv2();
-        this.reviews = createDummyReviews(univ1, univ2);
+        this.reviews = new ArrayList<>(createDummyReviews(univ1, univ2));
     }
 
     @Override
@@ -43,12 +48,29 @@ public class FakeUnivReviewRepository implements UnivReviewRepository {
         return new PageImpl<>(pageContent, pageable, filteredReviews.size());
     }
 
+    @Override
+    public UnivReview save(UnivReview univReview) {
+        Long newSeq = sequenceGenerator.incrementAndGet();
+
+        ReflectionTestUtils.setField(univReview, "univReviewSeq", newSeq);
+
+        this.reviews.add(univReview);
+
+        return univReview;
+    }
+
     private List<UnivReview> createDummyReviews(University univ1, University univ2) {
         return List.of(
-                UnivReview.builder().university(univ1).foodScore(5).dormScore(5).convScore(5).campusScore(5).overallScore(5).reviewText("리뷰1").createUser("user1").createDate(LocalDateTime.now()).build(),
-                UnivReview.builder().university(univ1).foodScore(4).dormScore(4).convScore(4).campusScore(4).overallScore(4).reviewText("리뷰2").createUser("user2").createDate(LocalDateTime.now().minusDays(1)).build(),
-                UnivReview.builder().university(univ1).foodScore(3).dormScore(3).convScore(3).campusScore(3).overallScore(3).reviewText("리뷰3").createUser("user3").createDate(LocalDateTime.now().minusDays(2)).build(),
-                UnivReview.builder().university(univ1).foodScore(5).dormScore(5).convScore(5).campusScore(5).overallScore(5).reviewText("리뷰4").createUser("user4").createDate(LocalDateTime.now()).build()
+                UnivReview.builder().university(univ1).foodScore(5).dormScore(5).convScore(5).campusScore(5).overallScore(5).reviewText("리뷰1").createDate(LocalDateTime.now()).build(),
+                UnivReview.builder().university(univ1).foodScore(4).dormScore(4).convScore(4).campusScore(4).overallScore(4).reviewText("리뷰2").createDate(LocalDateTime.now().minusDays(1)).build(),
+                UnivReview.builder().university(univ1).foodScore(3).dormScore(3).convScore(3).campusScore(3).overallScore(3).reviewText("리뷰3").createDate(LocalDateTime.now().minusDays(2)).build(),
+                UnivReview.builder().university(univ1).foodScore(5).dormScore(5).convScore(5).campusScore(5).overallScore(5).reviewText("리뷰4").createDate(LocalDateTime.now()).build()
         );
     }
+
+    public List<UnivReview> getReviews() {
+        return this.reviews;
+    }
+
+
 }

--- a/src/test/java/com/kakao/uniscope/univ/univReview/UnivReviewControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/univReview/UnivReviewControllerTest.java
@@ -1,0 +1,73 @@
+package com.kakao.uniscope.univ.univReview;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
+import com.kakao.uniscope.univ.review.controller.UnivReviewController;
+import com.kakao.uniscope.univ.review.dto.ReviewCreateResponse;
+import com.kakao.uniscope.univ.review.dto.UnivReviewRequest;
+import com.kakao.uniscope.univ.review.service.UnivReviewService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.mockito.Mockito.*;
+
+@WebMvcTest(controllers = UnivReviewController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
+public class UnivReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UnivReviewService univReviewService;
+
+    @Test
+    void 대학_리뷰_작성_성공_201_Created() throws Exception {
+        UnivReviewRequest request = createRequestDto(1L);
+
+        Long newReviewSeq = 1L;
+        ReviewCreateResponse mockResponse = ReviewCreateResponse.of(newReviewSeq);
+
+        when(univReviewService.createReview(eq(request))).thenReturn(mockResponse);
+
+        mockMvc.perform(post("/api/reviews/univ")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.reviewSeq").value(newReviewSeq));
+
+        verify(univReviewService, times(1)).createReview(eq(request));
+    }
+
+    @Test
+    void 리뷰_작성_실패_대학을_찾을_수_없음() throws Exception {
+        Long notExistUnivSeq = 999L;
+        UnivReviewRequest request = createRequestDto(notExistUnivSeq);
+
+        when(univReviewService.createReview(eq(request))).thenThrow(new ResourceNotFoundException(notExistUnivSeq + "에 해당하는 대학교를 찾을 수 없습니다."));
+
+        mockMvc.perform(post("/api/reviews/univ")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+
+        verify(univReviewService, times(1)).createReview(eq(request));
+    }
+
+    private UnivReviewRequest createRequestDto(Long univSeq) {
+        return new UnivReviewRequest(
+                univSeq, 5, 4, 3, 4, 5, "유효한 리뷰 텍스트."
+        );
+    }
+}

--- a/src/test/java/com/kakao/uniscope/univ/univReview/UnivReviewServiceTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/univReview/UnivReviewServiceTest.java
@@ -2,6 +2,8 @@ package com.kakao.uniscope.univ.univReview;
 
 import com.kakao.uniscope.common.exception.ResourceNotFoundException;
 import com.kakao.uniscope.univ.FakeUnivRepository;
+import com.kakao.uniscope.univ.review.dto.ReviewCreateResponse;
+import com.kakao.uniscope.univ.review.dto.UnivReviewRequest;
 import com.kakao.uniscope.univ.review.dto.UnivReviewResponseDto;
 import com.kakao.uniscope.univ.review.service.UnivReviewService;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,12 +14,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class UnivReviewServiceTest {
 
+    private FakeUnivReviewRepository fakeUnivReviewRepository;
     private UnivReviewService univReviewService;
 
     @BeforeEach
     void setUp() {
         FakeUnivRepository fakeUnivRepository = new FakeUnivRepository();
-        FakeUnivReviewRepository fakeUnivReviewRepository = new FakeUnivReviewRepository();
+        this.fakeUnivReviewRepository = new FakeUnivReviewRepository();
         this.univReviewService = new UnivReviewService(fakeUnivRepository, fakeUnivReviewRepository);
     }
 
@@ -51,5 +54,40 @@ public class UnivReviewServiceTest {
         Pageable pageable = Pageable.ofSize(10).withPage(0);
 
         assertThrows(ResourceNotFoundException.class, () -> univReviewService.getAllUnivReviews(univSeq, pageable));
+    }
+
+    // 대학 리뷰 작성 API 테스트
+
+    @Test
+    void 대학_리뷰_작성_성공_메서드가_정상적으로_작동하고_응답을_반환하는지_검증() {
+        Long univSeq = 1L;
+
+        UnivReviewRequest request = createRequestDto(univSeq);
+
+        ReviewCreateResponse response = univReviewService.createReview(request);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    void 대학_리뷰_작성시에_리포지토리에_리뷰가_저장되는지_검증() {
+        Long univSeq = 1L;
+        UnivReviewRequest request = createRequestDto(univSeq);
+
+        int initialReviewCount = fakeUnivReviewRepository.getReviews().size();
+
+        ReviewCreateResponse response = univReviewService.createReview(request);
+
+        // 리뷰 개수가 1 증가했는지 확인
+        assertEquals(initialReviewCount + 1, fakeUnivReviewRepository.getReviews().size());
+
+        // 저장된 리뷰 내용이 요청 데이터와 일치하는지 확인 (리뷰 텍스트 확인)
+        assertEquals(request.reviewText(), fakeUnivReviewRepository.getReviews().getLast().getReviewText());
+    }
+
+    private UnivReviewRequest createRequestDto(Long univSeq) {
+        return new UnivReviewRequest(
+                univSeq, 5, 4, 3, 4, 5, "유효한 리뷰 텍스트."
+        );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #47 

## 🚀 작업 내용 (변경 사항)

사용자가 대학 리뷰를 작성할 수 있도록 하는 API를 구현했습니다.
변경 사항은 아래와 같습니다.

- 대학 리뷰 엔티티(UnivReview.java)에서 `createUser` 필드 삭제, DTO 수정
  - 대학 리뷰를 누가 작성했는지에 대한 정보를 삭제했습니다.

-  `POST /api/reviews/univ` 엔드포인트 구현
  - 요청 바디를 통해 평가 정보를 받아 리뷰를 저장하고, 응답을 반환합니다.
  - 응답 값은 리뷰 시퀀스(id)와 리뷰의 작성 일시입니다.

### 📸 스크린샷

<img width="927" height="471" alt="image" src="https://github.com/user-attachments/assets/a59490bc-9544-4b27-9491-3f48a540df9d" />

## 📢 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> r : 꼭 반영 해주세요 (request changes)
> c : 웬만하면 반영해주세요 (comment)
> a : 그냥 의견 혹은 칭찬(칭찬이 중요, 개발을 계속 하게 만드는 원동력이 될 수 있음) (approve)

🤔 궁금한 점

현재 응답 값에는 리뷰 시퀀스와 작성 일시만을 반환하고 있는데, 응답 메시지나 bool 값(success)을 추가로 보내는 것이 더 좋은 구현인지 궁금합니다.

또한, 응답 dto에 추가된 데이터를 반환해주는 것은 어떤지 궁금합니다.
예를 들면 클라이언트 측에서 POST 요청을 보내고, 새로운 데이터를 확인하기 위해 GET 요청을 해야 하는 상황이 있을 수 있는데, POST 요청 시에 생성된 데이터 정보를 반환하면 좋지 않을까라는 생각을 하게 되었습니다. 
