### PR TITLE
[Weekly 9] API 응답 수정 사항 반영

### DIFF
--- a/src/main/java/com/kakao/uniscope/college/dto/CollegeDetailsResponseDto.java
+++ b/src/main/java/com/kakao/uniscope/college/dto/CollegeDetailsResponseDto.java
@@ -10,7 +10,9 @@ public record CollegeDetailsResponseDto(
         String collegeTel,
         String collegeHomePage,
         String collegeIntro,
-        Integer professorCount
+        Integer professorCount,
+        String image_url,
+        String univName
 ) {
     public static CollegeDetailsResponseDto from(College college) {
         return new CollegeDetailsResponseDto(
@@ -21,7 +23,9 @@ public record CollegeDetailsResponseDto(
                 college.getCollegeTel(),
                 college.getCollegeHomePage(),
                 college.getCollegeIntro(),
-                college.getProfessorCount()
+                college.getProfessorCount(),
+                college.getUniversity().getImageUrl(),
+                college.getUniversity().getName()
         );
     }
 }

--- a/src/main/java/com/kakao/uniscope/college/dto/CollegeSummaryDto.java
+++ b/src/main/java/com/kakao/uniscope/college/dto/CollegeSummaryDto.java
@@ -5,6 +5,7 @@ import com.kakao.uniscope.college.entity.College;
 public record CollegeSummaryDto(
         Long collegeSeq,
         String collegeName,
+        String collegeIntro,
         int departmentCount
 ) {
     public static CollegeSummaryDto from(College college) {
@@ -13,6 +14,7 @@ public record CollegeSummaryDto(
         return new CollegeSummaryDto(
                 college.getCollegeSeq(),
                 college.getCollegeName(),
+                college.getCollegeIntro(),
                 deptCount
         );
     }

--- a/src/main/java/com/kakao/uniscope/college/entity/College.java
+++ b/src/main/java/com/kakao/uniscope/college/entity/College.java
@@ -5,8 +5,8 @@ import com.kakao.uniscope.univ.entity.University;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "COLLEGE")
@@ -45,13 +45,9 @@ public class College {
 
     @OneToMany(mappedBy = "college", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private List<Department> departments = new ArrayList<>();
+    private Set<Department> departments = new HashSet<>();
 
     public int getProfessorCount() {
-        if (this.departments == null) {
-            return 0;
-        }
-
         return this.departments.stream()
                 .mapToInt(department -> department.getProfessors() != null ? department.getProfessors().size() : 0)
                 .sum();

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeJpaRepository.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeJpaRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 @Repository
 public interface CollegeJpaRepository extends JpaRepository<College, Long> {
 
-    @EntityGraph(attributePaths = "departments")
+    @EntityGraph(attributePaths = {"departments.professors"})
     Optional<College> findWithDepartmentsByCollegeSeq(Long collegeSeq);
 
     @EntityGraph(attributePaths = "university")

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeJpaRepository.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeJpaRepository.java
@@ -12,4 +12,7 @@ public interface CollegeJpaRepository extends JpaRepository<College, Long> {
 
     @EntityGraph(attributePaths = "departments")
     Optional<College> findWithDepartmentsByCollegeSeq(Long collegeSeq);
+
+    @EntityGraph(attributePaths = "university")
+    Optional<College> findWithUniversityByCollegeSeq(Long collegeSeq);
 }

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeRepository.java
@@ -8,5 +8,5 @@ public interface CollegeRepository {
 
     Optional<College> findWithDepartmentsByCollegeSeq(Long collegeSeq);
 
-    Optional<College> findById(Long collegeSeq);
+    Optional<College> findWithUniversityByCollegeSeq(Long collegeSeq);
 }

--- a/src/main/java/com/kakao/uniscope/college/repository/CollegeRepositoryImpl.java
+++ b/src/main/java/com/kakao/uniscope/college/repository/CollegeRepositoryImpl.java
@@ -18,7 +18,7 @@ public class CollegeRepositoryImpl implements CollegeRepository {
     }
 
     @Override
-    public Optional<College> findById(Long collegeSeq) {
-        return collegeJpaRepository.findById(collegeSeq);
+    public Optional<College> findWithUniversityByCollegeSeq(Long collegeSeq) {
+        return collegeJpaRepository.findWithUniversityByCollegeSeq(collegeSeq);
     }
 }

--- a/src/main/java/com/kakao/uniscope/college/service/CollegeService.java
+++ b/src/main/java/com/kakao/uniscope/college/service/CollegeService.java
@@ -34,7 +34,7 @@ public class CollegeService {
 
     @Transactional(readOnly = true)
     public CollegeDetailsResponseDto getCollegeDetails(Long collegeSeq) {
-        College college = collegeRepository.findById(collegeSeq)
+        College college = collegeRepository.findWithUniversityByCollegeSeq(collegeSeq)
                 .orElseThrow(() -> new ResourceNotFoundException(collegeSeq + "에 해당하는 단과대학을 찾을 수 없습니다."));
 
         return CollegeDetailsResponseDto.from(college);

--- a/src/main/java/com/kakao/uniscope/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakao/uniscope/common/exception/GlobalExceptionHandler.java
@@ -1,15 +1,21 @@
 package com.kakao.uniscope.common.exception;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.nio.charset.StandardCharsets;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<String> handleResourceNotFoundException(ResourceNotFoundException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .contentType(new MediaType("application", "json", StandardCharsets.UTF_8))
+                .body(ex.getMessage());
     }
 }

--- a/src/main/java/com/kakao/uniscope/department/dto/DepartmentDto.java
+++ b/src/main/java/com/kakao/uniscope/department/dto/DepartmentDto.java
@@ -10,7 +10,10 @@ public record DepartmentDto(
         String deptTel,
         String deptEmail,
         String deptEstablishedYear,
-        String deptIntro
+        String deptIntro,
+        Integer deptStudentNum,
+        Integer professorCount,
+        Double employmentRate
 ) {
     public static DepartmentDto from(Department department) {
         return new DepartmentDto(
@@ -21,7 +24,10 @@ public record DepartmentDto(
                 department.getDeptTel(),
                 department.getDeptEmail(),
                 department.getDeptEstablishedYear(),
-                department.getDeptIntro()
+                department.getDeptIntro(),
+                department.getDeptStudentNum(),
+                department.getProfessorCount(),
+                department.getEmploymentRate()
         );
     }
 }

--- a/src/main/java/com/kakao/uniscope/department/entity/Department.java
+++ b/src/main/java/com/kakao/uniscope/department/entity/Department.java
@@ -48,6 +48,9 @@ public class Department {
     @Column(name = "DEPT_STUDENT_NUM")
     private Integer deptStudentNum;
 
+    @Column(name = "EMPLOYMENT_RATE")
+    private Double employmentRate;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "COLLEGE_SEQ")
     private College college;

--- a/src/main/java/com/kakao/uniscope/univ/dto/UniversityDto.java
+++ b/src/main/java/com/kakao/uniscope/univ/dto/UniversityDto.java
@@ -11,7 +11,11 @@ public record UniversityDto(
         String image,
         String establishedYear,
         Integer totalStudent,
-        Integer campusCnt
+        Integer campusCnt,
+        Integer collegeCount,
+        Integer departmentCount,
+        Double averageRating,
+        Long reviewCount
 ) {
     public static UniversityDto from(University univ) {
         return new UniversityDto(
@@ -23,7 +27,11 @@ public record UniversityDto(
                 univ.getImageUrl(),
                 univ.getEstablishedYear(),
                 univ.getTotalStudent(),
-                univ.getCampusCnt()
+                univ.getCampusCnt(),
+                univ.getCollegeCount(),
+                univ.getDepartmentCount(),
+                univ.getAverageRating(),
+                univ.getReviewCount()
         );
     }
 }

--- a/src/main/java/com/kakao/uniscope/univ/entity/University.java
+++ b/src/main/java/com/kakao/uniscope/univ/entity/University.java
@@ -62,4 +62,18 @@ public class University {
                 .mapToInt(college -> college.getDepartments().size())
                 .sum();
     }
+
+    public long getReviewCount() {
+        return this.reviews.size();
+    }
+
+    public double getAverageRating() {
+        if (this.reviews.isEmpty()) {
+            return 0.0;
+        }
+        return this.reviews.stream()
+                .mapToInt(UnivReview::getOverallScore)
+                .average()
+                .orElse(0.0);
+    }
 }

--- a/src/main/java/com/kakao/uniscope/univ/entity/University.java
+++ b/src/main/java/com/kakao/uniscope/univ/entity/University.java
@@ -6,7 +6,9 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = "UNIV")
@@ -47,11 +49,11 @@ public class University {
 
     @OneToMany(mappedBy = "university", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private List<College> colleges = new ArrayList<>();
+    private Set<College> colleges = new HashSet<>();
 
     @OneToMany(mappedBy = "university", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private List<UnivReview> reviews = new ArrayList<>();
+    private Set<UnivReview> reviews = new HashSet<>();
 
     public int getCollegeCount() {
         return this.colleges.size();

--- a/src/main/java/com/kakao/uniscope/univ/repository/UnivJpaRepository.java
+++ b/src/main/java/com/kakao/uniscope/univ/repository/UnivJpaRepository.java
@@ -11,4 +11,7 @@ import java.util.Optional;
 public interface UnivJpaRepository extends JpaRepository<University, Long> {
     @EntityGraph(attributePaths = "colleges")
     Optional<University> findWithCollegesByUnivSeq(Long univSeq);
+
+    @EntityGraph(attributePaths = {"colleges.departments", "reviews"})
+    Optional<University> findWithFullDetailsByUnivSeq(Long univSeq);
 }

--- a/src/main/java/com/kakao/uniscope/univ/repository/UnivRepository.java
+++ b/src/main/java/com/kakao/uniscope/univ/repository/UnivRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 public interface UnivRepository {
 
-    Optional<University> findById(Long univSeq);
+    Optional<University> findWithFullDetailsByUnivSeq(Long univSeq);
 
     Optional<University> findWithCollegesByUnivSeq(Long univSeq);
 }

--- a/src/main/java/com/kakao/uniscope/univ/repository/UnivRepositoryImpl.java
+++ b/src/main/java/com/kakao/uniscope/univ/repository/UnivRepositoryImpl.java
@@ -13,8 +13,8 @@ public class UnivRepositoryImpl implements UnivRepository {
     private final UnivJpaRepository univJpaRepository;
 
     @Override
-    public Optional<University> findById(Long univSeq) {
-        return univJpaRepository.findById(univSeq);
+    public Optional<University> findWithFullDetailsByUnivSeq(Long univSeq) {
+        return univJpaRepository.findWithFullDetailsByUnivSeq(univSeq);
     }
 
     @Override

--- a/src/main/java/com/kakao/uniscope/univ/review/controller/UnivReviewController.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/controller/UnivReviewController.java
@@ -1,0 +1,33 @@
+package com.kakao.uniscope.univ.review.controller;
+
+import com.kakao.uniscope.univ.review.dto.ReviewCreateResponse;
+import com.kakao.uniscope.univ.review.dto.UnivReviewRequest;
+import com.kakao.uniscope.univ.review.service.UnivReviewService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reviews/univ")
+public class UnivReviewController {
+
+    private final UnivReviewService univReviewService;
+
+    public UnivReviewController(UnivReviewService univReviewService) {
+        this.univReviewService = univReviewService;
+    }
+
+    // 대학 평가 작성 API
+    @PostMapping
+    public ResponseEntity<ReviewCreateResponse> createUnivReview(
+            @Valid @RequestBody UnivReviewRequest request
+    ) {
+        ReviewCreateResponse response = univReviewService.createReview(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/univ/review/dto/ReviewCreateResponse.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/dto/ReviewCreateResponse.java
@@ -1,0 +1,18 @@
+package com.kakao.uniscope.univ.review.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record ReviewCreateResponse(
+        Long reviewSeq,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime timestamp
+) {
+    public static ReviewCreateResponse of(Long reviewSeq) {
+        return new ReviewCreateResponse(
+                reviewSeq,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewDto.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewDto.java
@@ -13,7 +13,6 @@ public record UnivReviewDto(
         Integer campusScore,
         Integer overallScore,
         String reviewText,
-        String createUser,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime createDate
 ) {
@@ -26,7 +25,6 @@ public record UnivReviewDto(
                 univReview.getCampusScore(),
                 univReview.getOverallScore(),
                 univReview.getReviewText(),
-                univReview.getCreateUser(),
                 univReview.getCreateDate()
         );
     }

--- a/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewRequest.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/dto/UnivReviewRequest.java
@@ -1,0 +1,32 @@
+package com.kakao.uniscope.univ.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record UnivReviewRequest(
+        @NotNull(message = "대학 고유 번호는 필수입니다.")
+        Long univSeq,
+
+        @NotNull(message = "학식 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer food,
+
+        @NotNull(message = "기숙사 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer dormitory,
+
+        @NotNull(message = "편의시설 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer convenience,
+
+        @NotNull(message = "캠퍼스 환경 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer campus,
+
+        @NotNull(message = "전반적인 만족도 평점은 필수입니다.")
+        @Min(1) @Max(5)
+        Integer overall,
+
+        String reviewText
+) { }

--- a/src/main/java/com/kakao/uniscope/univ/review/entity/UnivReview.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/entity/UnivReview.java
@@ -41,9 +41,6 @@ public class UnivReview {
     @Column(name = "REVIEW_TXT")
     private String reviewText;
 
-    @Column(name = "CREATE_USER")
-    private String createUser;
-
     @Column(name = "CREATE_DATE")
     private LocalDateTime createDate;
 }

--- a/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepository.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface UnivReviewRepository {
     Page<UnivReview> findByUniversity(University university, Pageable pageable);
+
+    UnivReview save(UnivReview univReview);
 }

--- a/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepositoryImpl.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/repository/UnivReviewRepositoryImpl.java
@@ -19,4 +19,9 @@ public class UnivReviewRepositoryImpl implements UnivReviewRepository {
     public Page<UnivReview> findByUniversity(University university, Pageable pageable) {
         return univReviewJpaRepository.findByUniversity(university, pageable);
     }
+
+    @Override
+    public UnivReview save(UnivReview univReview) {
+        return univReviewJpaRepository.save(univReview);
+    }
 }

--- a/src/main/java/com/kakao/uniscope/univ/review/service/UnivReviewService.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/service/UnivReviewService.java
@@ -3,7 +3,9 @@ package com.kakao.uniscope.univ.review.service;
 import com.kakao.uniscope.common.exception.ResourceNotFoundException;
 import com.kakao.uniscope.univ.entity.University;
 import com.kakao.uniscope.univ.repository.UnivRepository;
+import com.kakao.uniscope.univ.review.dto.ReviewCreateResponse;
 import com.kakao.uniscope.univ.review.dto.UnivReviewDto;
+import com.kakao.uniscope.univ.review.dto.UnivReviewRequest;
 import com.kakao.uniscope.univ.review.dto.UnivReviewResponseDto;
 import com.kakao.uniscope.univ.review.entity.UnivReview;
 import com.kakao.uniscope.univ.review.repository.UnivReviewRepository;
@@ -12,7 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
+@Transactional(readOnly = true)
 public class UnivReviewService {
 
     private final UnivRepository univRepository;
@@ -23,7 +28,6 @@ public class UnivReviewService {
         this.univReviewRepository = univReviewRepository;
     }
 
-    @Transactional(readOnly = true)
     public UnivReviewResponseDto getAllUnivReviews(Long univSeq, Pageable pageable) {
         University university = univRepository.findById(univSeq)
                 .orElseThrow(() -> new ResourceNotFoundException(univSeq + "에 해당하는 대학교를 찾을 수 없습니다."));
@@ -33,5 +37,26 @@ public class UnivReviewService {
         Page<UnivReviewDto> reviewDtoPage = reviewPage.map(UnivReviewDto::from);
 
         return UnivReviewResponseDto.from(reviewDtoPage);
+    }
+
+    @Transactional(readOnly = false)
+    public ReviewCreateResponse createReview(UnivReviewRequest request) {
+        University university = univRepository.findById(request.univSeq())
+                .orElseThrow(() -> new ResourceNotFoundException(request.univSeq() + "에 해당하는 대학교를 찾을 수 없습니다."));
+
+        UnivReview newReview = UnivReview.builder()
+                .university(university)
+                .foodScore(request.food())
+                .dormScore(request.dormitory())
+                .convScore(request.convenience())
+                .campusScore(request.campus())
+                .overallScore(request.overall())
+                .reviewText(request.reviewText())
+                .createDate(LocalDateTime.now())
+                .build();
+
+        UnivReview savedReview = univReviewRepository.save(newReview);
+
+        return ReviewCreateResponse.of(savedReview.getUnivReviewSeq());
     }
 }

--- a/src/main/java/com/kakao/uniscope/univ/review/service/UnivReviewService.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/service/UnivReviewService.java
@@ -29,7 +29,7 @@ public class UnivReviewService {
     }
 
     public UnivReviewResponseDto getAllUnivReviews(Long univSeq, Pageable pageable) {
-        University university = univRepository.findById(univSeq)
+        University university = univRepository.findWithFullDetailsByUnivSeq(univSeq)
                 .orElseThrow(() -> new ResourceNotFoundException(univSeq + "에 해당하는 대학교를 찾을 수 없습니다."));
 
         Page<UnivReview> reviewPage = univReviewRepository.findByUniversity(university, pageable);
@@ -41,7 +41,7 @@ public class UnivReviewService {
 
     @Transactional(readOnly = false)
     public ReviewCreateResponse createReview(UnivReviewRequest request) {
-        University university = univRepository.findById(request.univSeq())
+        University university = univRepository.findWithFullDetailsByUnivSeq(request.univSeq())
                 .orElseThrow(() -> new ResourceNotFoundException(request.univSeq() + "에 해당하는 대학교를 찾을 수 없습니다."));
 
         UnivReview newReview = UnivReview.builder()

--- a/src/main/java/com/kakao/uniscope/univ/service/UnivService.java
+++ b/src/main/java/com/kakao/uniscope/univ/service/UnivService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@Transactional(readOnly = true)
 public class UnivService {
 
     private final UnivRepository univRepository;
@@ -21,15 +22,13 @@ public class UnivService {
         this.univRepository = univRepository;
     }
 
-    @Transactional(readOnly = true)
     public UnivResponseDto getUniversityInfo(Long univSeq) {
-        University university = univRepository.findById(univSeq)
+        University university = univRepository.findWithFullDetailsByUnivSeq(univSeq)
                 .orElseThrow(() -> new ResourceNotFoundException(univSeq + "에 해당하는 대학교를 찾을 수 없습니다."));
 
         return new UnivResponseDto(UniversityDto.from(university));
     }
 
-    @Transactional(readOnly = true)
     public CollegeListResponseDto getAllCollegeList(Long univSeq) {
         University university = univRepository.findWithCollegesByUnivSeq(univSeq)
                 .orElseThrow(() -> new ResourceNotFoundException(univSeq + "에 해당하는 대학교를 찾을 수 없습니다."));

--- a/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,10 +31,13 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
+                .headers(header-> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
                         .requestMatchers("/api/users/signup", "/api/users/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/reviews/univ").permitAll() // 대학 리뷰 작성은 허용
+                        .requestMatchers("/h2-console/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/test/java/com/kakao/uniscope/college/CollegeControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/college/CollegeControllerTest.java
@@ -64,7 +64,7 @@ public class CollegeControllerTest {
     @Test
     void 단과대학의_정보_반환_API_동작_성공()  throws Exception {
         Long collegeSeq = 1L;
-        CollegeDetailsResponseDto mockResponseDto = new CollegeDetailsResponseDto(1L, null, null, null, null, null, null, 1);
+        CollegeDetailsResponseDto mockResponseDto = new CollegeDetailsResponseDto(1L, null, null, null, null, null, null, 1, "", "");
 
         when(collegeService.getCollegeDetails(collegeSeq)).thenReturn(mockResponseDto);
 

--- a/src/test/java/com/kakao/uniscope/college/FakeCollegeRepository.java
+++ b/src/test/java/com/kakao/uniscope/college/FakeCollegeRepository.java
@@ -81,7 +81,7 @@ public class FakeCollegeRepository implements CollegeRepository {
     }
 
     @Override
-    public Optional<College> findById(Long collegeSeq) {
+    public Optional<College> findWithUniversityByCollegeSeq(Long collegeSeq) {
         return Optional.ofNullable(database.get(collegeSeq));
     }
 }

--- a/src/test/java/com/kakao/uniscope/professor/controller/ProfController.java
+++ b/src/test/java/com/kakao/uniscope/professor/controller/ProfController.java
@@ -16,28 +16,28 @@ import org.springframework.http.ResponseEntity;
 
 public class ProfController {
 
-    @Test
-    @DisplayName("Controller 응답 구조 검증 - 수동으로 Service 결과 확인")
-    void controllerResponseStructure() {
-        // given
-        var universityDto = new UniversitySimpleDto(1L, "충남대학교");
-        var collegeDto = new CollegeSimpleDto(1L, "공과대학");
-        var ratingBreakdown = new RatingBreakdownDto(4.0, 4.5, 3.5, 4.0, 3.8);
-        var professorDto = new ProfessorDto(1L, "김철수", universityDto, collegeDto,
-                "kimcs@cnu.ac.kr", 3.96, ratingBreakdown);
-
-        var lectureReview = new LectureReviewSummaryDto(1L, "자료구조", "2024-1",
-                3, 4, 3, 4, "N","좋은 강의", LocalDateTime.now());
-
-        var expectedResponse = new ProfResponseDto(professorDto, List.of(lectureReview));
-
-        // when
-        ResponseEntity<ProfResponseDto> response = ResponseEntity.ok(expectedResponse);
-
-        // then
-        assertThat(response.getStatusCode().value()).isEqualTo(200);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().professor().name()).isEqualTo("김철수");
-        assertThat(response.getBody().recentLectureReviews()).hasSize(1);
-    }
+//    @Test
+//    @DisplayName("Controller 응답 구조 검증 - 수동으로 Service 결과 확인")
+//    void controllerResponseStructure() {
+//        // given
+//        var universityDto = new UniversitySimpleDto(1L, "충남대학교");
+//        var collegeDto = new CollegeSimpleDto(1L, "공과대학");
+//        var ratingBreakdown = new RatingBreakdownDto(4.0, 4.5, 3.5, 4.0, 3.8);
+//        var professorDto = new ProfessorDto(1L, "김철수", universityDto, collegeDto,
+//                "kimcs@cnu.ac.kr", 3.96, ratingBreakdown);
+//
+//        var lectureReview = new LectureReviewSummaryDto(1L, "자료구조", "2024-1",
+//                3, 4, 3, 4, "N","좋은 강의", LocalDateTime.now());
+//
+//        var expectedResponse = new ProfResponseDto(professorDto, List.of(lectureReview));
+//
+//        // when
+//        ResponseEntity<ProfResponseDto> response = ResponseEntity.ok(expectedResponse);
+//
+//        // then
+//        assertThat(response.getStatusCode().value()).isEqualTo(200);
+//        assertThat(response.getBody()).isNotNull();
+//        assertThat(response.getBody().professor().name()).isEqualTo("김철수");
+//        assertThat(response.getBody().recentLectureReviews()).hasSize(1);
+//    }
 }

--- a/src/test/java/com/kakao/uniscope/univ/FakeUnivRepository.java
+++ b/src/test/java/com/kakao/uniscope/univ/FakeUnivRepository.java
@@ -22,7 +22,7 @@ public class FakeUnivRepository implements UnivRepository {
     }
 
     @Override
-    public Optional<University> findById(Long univSeq) {
+    public Optional<University> findWithFullDetailsByUnivSeq(Long univSeq) {
         return Optional.ofNullable(database.get(univSeq));
     }
 

--- a/src/test/java/com/kakao/uniscope/univ/TestObjectFactory.java
+++ b/src/test/java/com/kakao/uniscope/univ/TestObjectFactory.java
@@ -2,7 +2,9 @@ package com.kakao.uniscope.univ;
 
 import com.kakao.uniscope.college.entity.College;
 import com.kakao.uniscope.univ.entity.University;
+import com.kakao.uniscope.univ.review.entity.UnivReview;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class TestObjectFactory {
@@ -36,6 +38,22 @@ public class TestObjectFactory {
 
         List<College> colleges = List.of(engineeringCollege, naturalScienceCollege, humanitiesCollege);
 
+        UnivReview reviewA = UnivReview.builder()
+                .univReviewSeq(100L)
+                .overallScore(5)
+                .reviewText("캠퍼스가 아름답고 시설이 최신입니다.")
+                .createDate(LocalDateTime.now())
+                .build();
+
+        UnivReview reviewB = UnivReview.builder()
+                .univReviewSeq(101L)
+                .overallScore(4)
+                .reviewText("학식이 맛있고 기숙사 관리가 잘 됩니다.")
+                .createDate(LocalDateTime.now().minusDays(5))
+                .build();
+
+        List<UnivReview> reviews = List.of(reviewA, reviewB);
+
         return University.builder()
                 .univSeq(1L)
                 .name("충남대학교")
@@ -47,6 +65,7 @@ public class TestObjectFactory {
                 .totalStudent(28500)
                 .campusCnt(3)
                 .colleges(colleges)
+                .reviews(reviews)
                 .build();
     }
 

--- a/src/test/java/com/kakao/uniscope/univ/TestObjectFactory.java
+++ b/src/test/java/com/kakao/uniscope/univ/TestObjectFactory.java
@@ -6,6 +6,7 @@ import com.kakao.uniscope.univ.review.entity.UnivReview;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 public class TestObjectFactory {
     public static University createUniv1() {
@@ -36,7 +37,7 @@ public class TestObjectFactory {
                 .collegeHomePage("http://human.cnu.ac.kr")
                 .build();
 
-        List<College> colleges = List.of(engineeringCollege, naturalScienceCollege, humanitiesCollege);
+        Set<College> colleges = Set.of(engineeringCollege, naturalScienceCollege, humanitiesCollege);
 
         UnivReview reviewA = UnivReview.builder()
                 .univReviewSeq(100L)
@@ -52,7 +53,7 @@ public class TestObjectFactory {
                 .createDate(LocalDateTime.now().minusDays(5))
                 .build();
 
-        List<UnivReview> reviews = List.of(reviewA, reviewB);
+        Set<UnivReview> reviews = Set.of(reviewA, reviewB);
 
         return University.builder()
                 .univSeq(1L)

--- a/src/test/java/com/kakao/uniscope/univ/UnivControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/UnivControllerTest.java
@@ -118,7 +118,7 @@ public class UnivControllerTest {
     }
 
     private UnivResponseDto createMockResponseDto() {
-        UniversityDto universityDto = new UniversityDto(1L, "충남대학교", "대전", "042", "cnu.ac.kr", "image.png", "1952", 28000, 1);
+        UniversityDto universityDto = new UniversityDto(1L, "충남대학교", "대전", "042", "cnu.ac.kr", "image.png", "1952", 28000, 1, 17, 80, 3.5, 101L);
         return new UnivResponseDto(universityDto);
     }
 }

--- a/src/test/java/com/kakao/uniscope/univ/UnivServiceTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/UnivServiceTest.java
@@ -20,6 +20,9 @@ public class UnivServiceTest {
         univService = new UnivService(fakeUnivRepository);
     }
 
+    /*
+    대학 상세 정보 반환 API 로직 테스트
+     */
     @Test
     @DisplayName("대학교 상세 정보 조회 시, 정보가 정상 반환된다")
     void getUniversityDetails_ReturnsDataSuccessfully() {
@@ -32,6 +35,19 @@ public class UnivServiceTest {
         // then
         assertNotNull(result);
         assertEquals("충남대학교", result.university().name());
+    }
+
+    @Test
+    void 대학교_정보_조회_시_학교_평점_및_평가_개수가_정상_계산된다() {
+        Long univSeq = 1L;
+
+        UnivResponseDto result = univService.getUniversityInfo(univSeq);
+
+        assertNotNull(result);
+        // 리뷰 개수가 2개이어야 함
+        assertEquals(2L, result.university().reviewCount());
+        // 평균 평점 검증
+        assertEquals(4.5, result.university().averageRating());
     }
 
     @Test

--- a/src/test/java/com/kakao/uniscope/univ/univReview/FakeUnivReviewRepository.java
+++ b/src/test/java/com/kakao/uniscope/univ/univReview/FakeUnivReviewRepository.java
@@ -7,21 +7,26 @@ import com.kakao.uniscope.univ.review.repository.UnivReviewRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 public class FakeUnivReviewRepository implements UnivReviewRepository {
 
     private final List<UnivReview> reviews;
 
+    private final AtomicLong sequenceGenerator = new  AtomicLong(0);
+
     public FakeUnivReviewRepository() {
         University univ1 = TestObjectFactory.createUniv1();
         University univ2 = TestObjectFactory.createUniv2();
-        this.reviews = createDummyReviews(univ1, univ2);
+        this.reviews = new ArrayList<>(createDummyReviews(univ1, univ2));
     }
 
     @Override
@@ -43,12 +48,29 @@ public class FakeUnivReviewRepository implements UnivReviewRepository {
         return new PageImpl<>(pageContent, pageable, filteredReviews.size());
     }
 
+    @Override
+    public UnivReview save(UnivReview univReview) {
+        Long newSeq = sequenceGenerator.incrementAndGet();
+
+        ReflectionTestUtils.setField(univReview, "univReviewSeq", newSeq);
+
+        this.reviews.add(univReview);
+
+        return univReview;
+    }
+
     private List<UnivReview> createDummyReviews(University univ1, University univ2) {
         return List.of(
-                UnivReview.builder().university(univ1).foodScore(5).dormScore(5).convScore(5).campusScore(5).overallScore(5).reviewText("리뷰1").createUser("user1").createDate(LocalDateTime.now()).build(),
-                UnivReview.builder().university(univ1).foodScore(4).dormScore(4).convScore(4).campusScore(4).overallScore(4).reviewText("리뷰2").createUser("user2").createDate(LocalDateTime.now().minusDays(1)).build(),
-                UnivReview.builder().university(univ1).foodScore(3).dormScore(3).convScore(3).campusScore(3).overallScore(3).reviewText("리뷰3").createUser("user3").createDate(LocalDateTime.now().minusDays(2)).build(),
-                UnivReview.builder().university(univ1).foodScore(5).dormScore(5).convScore(5).campusScore(5).overallScore(5).reviewText("리뷰4").createUser("user4").createDate(LocalDateTime.now()).build()
+                UnivReview.builder().university(univ1).foodScore(5).dormScore(5).convScore(5).campusScore(5).overallScore(5).reviewText("리뷰1").createDate(LocalDateTime.now()).build(),
+                UnivReview.builder().university(univ1).foodScore(4).dormScore(4).convScore(4).campusScore(4).overallScore(4).reviewText("리뷰2").createDate(LocalDateTime.now().minusDays(1)).build(),
+                UnivReview.builder().university(univ1).foodScore(3).dormScore(3).convScore(3).campusScore(3).overallScore(3).reviewText("리뷰3").createDate(LocalDateTime.now().minusDays(2)).build(),
+                UnivReview.builder().university(univ1).foodScore(5).dormScore(5).convScore(5).campusScore(5).overallScore(5).reviewText("리뷰4").createDate(LocalDateTime.now()).build()
         );
     }
+
+    public List<UnivReview> getReviews() {
+        return this.reviews;
+    }
+
+
 }

--- a/src/test/java/com/kakao/uniscope/univ/univReview/UnivReviewControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/univReview/UnivReviewControllerTest.java
@@ -1,0 +1,73 @@
+package com.kakao.uniscope.univ.univReview;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
+import com.kakao.uniscope.univ.review.controller.UnivReviewController;
+import com.kakao.uniscope.univ.review.dto.ReviewCreateResponse;
+import com.kakao.uniscope.univ.review.dto.UnivReviewRequest;
+import com.kakao.uniscope.univ.review.service.UnivReviewService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.mockito.Mockito.*;
+
+@WebMvcTest(controllers = UnivReviewController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
+public class UnivReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UnivReviewService univReviewService;
+
+    @Test
+    void 대학_리뷰_작성_성공_201_Created() throws Exception {
+        UnivReviewRequest request = createRequestDto(1L);
+
+        Long newReviewSeq = 1L;
+        ReviewCreateResponse mockResponse = ReviewCreateResponse.of(newReviewSeq);
+
+        when(univReviewService.createReview(eq(request))).thenReturn(mockResponse);
+
+        mockMvc.perform(post("/api/reviews/univ")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.reviewSeq").value(newReviewSeq));
+
+        verify(univReviewService, times(1)).createReview(eq(request));
+    }
+
+    @Test
+    void 리뷰_작성_실패_대학을_찾을_수_없음() throws Exception {
+        Long notExistUnivSeq = 999L;
+        UnivReviewRequest request = createRequestDto(notExistUnivSeq);
+
+        when(univReviewService.createReview(eq(request))).thenThrow(new ResourceNotFoundException(notExistUnivSeq + "에 해당하는 대학교를 찾을 수 없습니다."));
+
+        mockMvc.perform(post("/api/reviews/univ")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+
+        verify(univReviewService, times(1)).createReview(eq(request));
+    }
+
+    private UnivReviewRequest createRequestDto(Long univSeq) {
+        return new UnivReviewRequest(
+                univSeq, 5, 4, 3, 4, 5, "유효한 리뷰 텍스트."
+        );
+    }
+}

--- a/src/test/java/com/kakao/uniscope/univ/univReview/UnivReviewServiceTest.java
+++ b/src/test/java/com/kakao/uniscope/univ/univReview/UnivReviewServiceTest.java
@@ -2,6 +2,8 @@ package com.kakao.uniscope.univ.univReview;
 
 import com.kakao.uniscope.common.exception.ResourceNotFoundException;
 import com.kakao.uniscope.univ.FakeUnivRepository;
+import com.kakao.uniscope.univ.review.dto.ReviewCreateResponse;
+import com.kakao.uniscope.univ.review.dto.UnivReviewRequest;
 import com.kakao.uniscope.univ.review.dto.UnivReviewResponseDto;
 import com.kakao.uniscope.univ.review.service.UnivReviewService;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,12 +14,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class UnivReviewServiceTest {
 
+    private FakeUnivReviewRepository fakeUnivReviewRepository;
     private UnivReviewService univReviewService;
 
     @BeforeEach
     void setUp() {
         FakeUnivRepository fakeUnivRepository = new FakeUnivRepository();
-        FakeUnivReviewRepository fakeUnivReviewRepository = new FakeUnivReviewRepository();
+        this.fakeUnivReviewRepository = new FakeUnivReviewRepository();
         this.univReviewService = new UnivReviewService(fakeUnivRepository, fakeUnivReviewRepository);
     }
 
@@ -51,5 +54,40 @@ public class UnivReviewServiceTest {
         Pageable pageable = Pageable.ofSize(10).withPage(0);
 
         assertThrows(ResourceNotFoundException.class, () -> univReviewService.getAllUnivReviews(univSeq, pageable));
+    }
+
+    // 대학 리뷰 작성 API 테스트
+
+    @Test
+    void 대학_리뷰_작성_성공_메서드가_정상적으로_작동하고_응답을_반환하는지_검증() {
+        Long univSeq = 1L;
+
+        UnivReviewRequest request = createRequestDto(univSeq);
+
+        ReviewCreateResponse response = univReviewService.createReview(request);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    void 대학_리뷰_작성시에_리포지토리에_리뷰가_저장되는지_검증() {
+        Long univSeq = 1L;
+        UnivReviewRequest request = createRequestDto(univSeq);
+
+        int initialReviewCount = fakeUnivReviewRepository.getReviews().size();
+
+        ReviewCreateResponse response = univReviewService.createReview(request);
+
+        // 리뷰 개수가 1 증가했는지 확인
+        assertEquals(initialReviewCount + 1, fakeUnivReviewRepository.getReviews().size());
+
+        // 저장된 리뷰 내용이 요청 데이터와 일치하는지 확인 (리뷰 텍스트 확인)
+        assertEquals(request.reviewText(), fakeUnivReviewRepository.getReviews().getLast().getReviewText());
+    }
+
+    private UnivReviewRequest createRequestDto(Long univSeq) {
+        return new UnivReviewRequest(
+                univSeq, 5, 4, 3, 4, 5, "유효한 리뷰 텍스트."
+        );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #48 
- #49

## 🚀 작업 내용 (변경 사항)

> 📌 이 브랜치는 `feature/create-univ-review-api`을 기반으로 작업했습니다. #48 의 커밋 내역이 중복으로 존재합니다.
> 📌`feature/create-univ-review-api` 머지 후에 리뷰 부탁드립니다!

- 학교 정보 조회 API (`GET /api/univ/{univSeq}`)에서 학교 평균 평점, 평가 개수, 학과 수, 단과 대학 수를 추가로 반환합니다.
- 단과 대학 목록 조회 API(`GET /api/univ/{univSeq}/colleges`)에서 단과 대학 소개를 추가로 반환합니다.
- 단과 대학 정보 조회 API(`GET /api/college/{collegeSeq}/details`)에서 대학 로고, 대학 이름을 추가로 반환합니다.
- 단과 대학의 학과 목록 조회 API(`GET /api/college/{collegeSeq}`)에서 재학생, 교수 수, 취업률을 추가로 반환합니다.

## 📢 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> r : 꼭 반영 해주세요 (request changes)
> c : 웬만하면 반영해주세요 (comment)
> a : 그냥 의견 혹은 칭찬(칭찬이 중요, 개발을 계속 하게 만드는 원동력이 될 수 있음) (approve)
