### PR TITLE
[Weekly 11] 교수 비교 API 구현

### DIFF
--- a/src/main/java/com/kakao/uniscope/comparison/controller/ComparisonController.java
+++ b/src/main/java/com/kakao/uniscope/comparison/controller/ComparisonController.java
@@ -1,7 +1,9 @@
 package com.kakao.uniscope.comparison.controller;
 
+import com.kakao.uniscope.comparison.dto.ProfessorComparisonDto;
 import com.kakao.uniscope.comparison.dto.UniversityComparisonDto;
 import com.kakao.uniscope.comparison.service.ComparisonService;
+import com.kakao.uniscope.comparison.service.ProfessorComparisonService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,9 +18,12 @@ import java.util.List;
 public class ComparisonController {
 
     private final ComparisonService comparisonService;
+    private final ProfessorComparisonService professorComparisonService;
 
-    public ComparisonController(ComparisonService comparisonService) {
+    public ComparisonController(ComparisonService comparisonService,
+            ProfessorComparisonService professorComparisonService) {
         this.comparisonService = comparisonService;
+        this.professorComparisonService = professorComparisonService;
     }
 
     // 학교 비교 데이터 조회 API
@@ -27,6 +32,15 @@ public class ComparisonController {
             @RequestParam("univSeqs") List<Long> univSeqs
     ) {
         List<UniversityComparisonDto> response = comparisonService.getUniversitiesComparisonData(univSeqs);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    // 교수 비교 데이터 조회 API
+    @GetMapping("/professors")
+    public ResponseEntity<List<ProfessorComparisonDto>> getProfessorsComparisonData(
+            @RequestParam("profSeqs") List<Long> profSeqs
+    ) {
+        List<ProfessorComparisonDto> response = professorComparisonService.getProfessorsComparisonData(profSeqs);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/kakao/uniscope/comparison/dto/ProfessorComparisonDto.java
+++ b/src/main/java/com/kakao/uniscope/comparison/dto/ProfessorComparisonDto.java
@@ -1,0 +1,13 @@
+package com.kakao.uniscope.comparison.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ProfessorComparisonDto(
+        Long profSeq,
+        String profName,
+        String univName,
+        String deptName,
+        ProfessorScoreDto scores
+) {
+}

--- a/src/main/java/com/kakao/uniscope/comparison/dto/ProfessorScoreDto.java
+++ b/src/main/java/com/kakao/uniscope/comparison/dto/ProfessorScoreDto.java
@@ -1,0 +1,13 @@
+package com.kakao.uniscope.comparison.dto;
+
+public record ProfessorScoreDto(
+        Double theisPerformance,
+        Double researchPerformance,
+        Double homework,
+        Double lectureDifficulty,
+        Double examDifficulty
+) {
+    public static ProfessorScoreDto empty() {
+        return new ProfessorScoreDto(0.0, 0.0, 0.0, 0.0, 0.0);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/comparison/service/ProfessorComparisonService.java
+++ b/src/main/java/com/kakao/uniscope/comparison/service/ProfessorComparisonService.java
@@ -25,8 +25,8 @@ public class ProfessorComparisonService {
     private final LectureReviewRepository lectureReviewRepository;
 
     public List<ProfessorComparisonDto> getProfessorsComparisonData(List<Long> profSeqs) {
-        if (profSeqs == null || profSeqs.isEmpty() || profSeqs.size() > 2) {
-            throw new ComparisonException("비교할 교수 ID는 1개 이상 2개 이하로 제공되어야 합니다.");
+        if (profSeqs == null || profSeqs.isEmpty() || profSeqs.size() > 3) {
+            throw new ComparisonException("비교할 교수 ID는 1개 이상 3개 이하로 제공되어야 합니다.");
         }
 
         List<Professor> professors = professorRepository.findAllById(profSeqs);

--- a/src/main/java/com/kakao/uniscope/comparison/service/ProfessorComparisonService.java
+++ b/src/main/java/com/kakao/uniscope/comparison/service/ProfessorComparisonService.java
@@ -1,0 +1,82 @@
+package com.kakao.uniscope.comparison.service;
+
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
+import com.kakao.uniscope.comparison.dto.ProfessorComparisonDto;
+import com.kakao.uniscope.comparison.dto.ProfessorScoreDto;
+import com.kakao.uniscope.comparison.exception.ComparisonException;
+import com.kakao.uniscope.lecture.review.repository.LectureReviewRepository;
+import com.kakao.uniscope.professor.entity.Professor;
+import com.kakao.uniscope.professor.repository.ProfessorRepository;
+import com.kakao.uniscope.professor.review.repository.ProfReviewRepository;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProfessorComparisonService {
+
+    private final ProfessorRepository professorRepository;
+    private final ProfReviewRepository profReviewRepository;
+    private final LectureReviewRepository lectureReviewRepository;
+
+    public List<ProfessorComparisonDto> getProfessorsComparisonData(List<Long> profSeqs) {
+        if (profSeqs == null || profSeqs.isEmpty() || profSeqs.size() > 2) {
+            throw new ComparisonException("비교할 교수 ID는 1개 이상 2개 이하로 제공되어야 합니다.");
+        }
+
+        List<Professor> professors = professorRepository.findAllById(profSeqs);
+
+        if (professors.size() != profSeqs.size()) {
+            throw new ResourceNotFoundException("요청된 일부 교수 정보를 찾을 수 없거나 존재하지 않습니다.");
+        }
+
+        return professors.stream()
+                .map(this::toProfessorComparisonDto)
+                .collect(Collectors.toList());
+    }
+
+    private ProfessorComparisonDto toProfessorComparisonDto(Professor prof) {
+        ProfessorScoreDto scores = calculateScores(prof.getProfSeq());
+
+        return ProfessorComparisonDto.builder()
+                .profSeq(prof.getProfSeq())
+                .profName(prof.getProfName())
+                .univName(prof.getDepartment().getCollege().getUniversity().getName())
+                .deptName(prof.getDepartment().getDeptName())
+                .scores(scores)
+                .build();
+    }
+
+    private ProfessorScoreDto calculateScores(Long profSeq) {
+        // 교수 평가 통계
+        Double avgThesisPerf = findAvg(() -> profReviewRepository.findAvgThesisPerf(profSeq));
+        Double avgResearchPerf = findAvg(() -> profReviewRepository.findAvgResearchPerf(profSeq));
+
+        // 강의 평가 통계
+        Double avgHomework = findAvg(() -> lectureReviewRepository.findAvgHomework(profSeq));
+        Double avgLecDifficulty = findAvg(() -> lectureReviewRepository.findAvgLecDifficulty(profSeq));
+        Double avgExamDifficulty = findAvg(() -> lectureReviewRepository.findAvgExamDifficulty(profSeq));
+
+        return new ProfessorScoreDto(
+                avgThesisPerf,
+                avgResearchPerf,
+                avgHomework,
+                avgLecDifficulty,
+                avgExamDifficulty
+        );
+    }
+
+    private Double findAvg(Supplier<Double> supplier) {
+        try {
+            Double result = supplier.get();
+            return result != null ? result : 0.0;
+        } catch (Exception e) {
+            return 0.0;
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #65 

## 🚀 작업 내용

- 교수 비교를 위한 dto
- ProfessorComparisionService 구현
- ComparisionController에 교수 비교 API 엔드포인트 추가


### 📸 스크린샷 (선택) 
<img width="1480" height="1282" alt="image" src="https://github.com/user-attachments/assets/8ba42626-cb7c-49f6-958b-fae68f7faa01" />

## 📢 참고 사항

엔드포인트 controller를 따로 만들까했지만 
비교 controller 안에 나타내는게 한눈에 들어올 것 같아서 하나에 추가했습니다!