### PR TITLE
[Weekly 11] 교수 평가 API 구현

### DIFF
--- a/src/main/java/com/kakao/uniscope/professor/review/controller/ProfReviewController.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/controller/ProfReviewController.java
@@ -1,0 +1,28 @@
+package com.kakao.uniscope.professor.review.controller;
+
+import com.kakao.uniscope.professor.review.dto.ProfReviewRequest;
+import com.kakao.uniscope.professor.review.dto.ProfReviewResponse;
+import com.kakao.uniscope.professor.review.service.ProfReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reviews/prof")
+@RequiredArgsConstructor
+public class ProfReviewController {
+
+    private final ProfReviewService profReviewService;
+
+    @PostMapping
+    public ResponseEntity<ProfReviewResponse> createProfReview(
+            @RequestBody ProfReviewRequest request
+    ) {
+        ProfReviewResponse response = profReviewService.createReview(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/review/dto/ProfReviewRequest.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/dto/ProfReviewRequest.java
@@ -1,0 +1,9 @@
+package com.kakao.uniscope.professor.review.dto;
+
+public record ProfReviewRequest(
+        Long profSeq,
+        Integer thesisPerformance, // 논문실적
+        Integer researchPerformance, // 연구실적
+        String reviewText
+) {
+}

--- a/src/main/java/com/kakao/uniscope/professor/review/dto/ProfReviewResponse.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/dto/ProfReviewResponse.java
@@ -1,0 +1,17 @@
+package com.kakao.uniscope.professor.review.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
+public record ProfReviewResponse(
+        Long reviewSeq,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime timestamp
+) {
+    public static ProfReviewResponse of(Long reviewSeq) {
+        return new ProfReviewResponse(
+                reviewSeq,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/kakao/uniscope/professor/review/dto/ProfReviewResponse.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/dto/ProfReviewResponse.java
@@ -1,6 +1,7 @@
 package com.kakao.uniscope.professor.review.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.kakao.uniscope.professor.review.entity.ProfReview;
 import java.time.LocalDateTime;
 
 public record ProfReviewResponse(
@@ -8,10 +9,10 @@ public record ProfReviewResponse(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime timestamp
 ) {
-    public static ProfReviewResponse of(Long reviewSeq) {
+    public static ProfReviewResponse of(ProfReview review) {
         return new ProfReviewResponse(
-                reviewSeq,
-                LocalDateTime.now()
+                review.getProfReviewSeq(),
+                review.getCreateDate()
         );
     }
 }

--- a/src/main/java/com/kakao/uniscope/professor/review/entity/ProfReview.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/entity/ProfReview.java
@@ -10,13 +10,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "PROF_REVIEW")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProfReview {
 
@@ -37,4 +42,7 @@ public class ProfReview {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "PROF_SEQ")
     private Professor professor;
+
+    @Column(name = "CREATE_DATE")
+    private LocalDateTime createDate;
 }

--- a/src/main/java/com/kakao/uniscope/professor/review/service/ProfReviewService.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/service/ProfReviewService.java
@@ -36,6 +36,6 @@ public class ProfReviewService {
 
         ProfReview savedReview = profReviewRepository.save(newReview);
 
-        return ProfReviewResponse.of(savedReview.getProfReviewSeq());
+        return ProfReviewResponse.of(savedReview);
     }
 }

--- a/src/main/java/com/kakao/uniscope/professor/review/service/ProfReviewService.java
+++ b/src/main/java/com/kakao/uniscope/professor/review/service/ProfReviewService.java
@@ -1,0 +1,41 @@
+package com.kakao.uniscope.professor.review.service;
+
+import com.kakao.uniscope.common.exception.ResourceNotFoundException;
+import com.kakao.uniscope.professor.entity.Professor;
+import com.kakao.uniscope.professor.repository.ProfessorRepository;
+import com.kakao.uniscope.professor.review.dto.ProfReviewRequest;
+import com.kakao.uniscope.professor.review.dto.ProfReviewResponse;
+import com.kakao.uniscope.professor.review.entity.ProfReview;
+import com.kakao.uniscope.professor.review.repository.ProfReviewRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProfReviewService {
+
+    private final ProfessorRepository professorRepository;
+    private final ProfReviewRepository profReviewRepository;
+
+    @Transactional
+    public ProfReviewResponse createReview(ProfReviewRequest request) {
+
+        Professor professor = professorRepository.findById(request.profSeq())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        request.profSeq() + "에 해당하는 교수를 찾을 수 없습니다."));
+
+        ProfReview newReview = ProfReview.builder()
+                .professor(professor)
+                .thesisPerf(request.thesisPerformance())
+                .researchPerf(request.researchPerformance())
+                .thesisReview(request.reviewText())
+                .createDate(LocalDateTime.now())
+                .build();
+
+        ProfReview savedReview = profReviewRepository.save(newReview);
+
+        return ProfReviewResponse.of(savedReview.getProfReviewSeq());
+    }
+}

--- a/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
@@ -36,7 +36,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
                         .requestMatchers("/api/users/signup", "/api/users/login", "/api/users/email/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/reviews/univ").permitAll() // 대학 리뷰 작성은 허용
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/reviews/univ",      // 대학 리뷰
+                                "/api/reviews/prof",      // 교수 리뷰
+                                "/api/reviews/lecture"    // 강의 리뷰
+                        ).permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .anyRequest().authenticated()
                 );


### PR DESCRIPTION
## #️⃣연관된 이슈
- #66 


## 🚀 작업 내용

- 교수 평가 등록 api 구현 (논문 평가, 연구 실적, 논문에 대한 의견)

### 📸 스크린샷 (선택) 
<img width="1471" height="878" alt="image" src="https://github.com/user-attachments/assets/1ae13ac0-50c1-4145-b2de-e00f77a10eed" />


## 📢 참고 사항

a:
SecurityConfig에서 교수 평가와 강의 평가 엔드포인트 추가했습니다