### PR TITLE
[Weekly 11] 학과 정보 조회 API 반환값 추가

### DIFF
--- a/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
+++ b/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
@@ -1,8 +1,10 @@
 package com.kakao.uniscope.department.dto;
 
+import com.kakao.uniscope.college.entity.College;
 import com.kakao.uniscope.department.careerField.dto.CareerFieldDto;
 import com.kakao.uniscope.department.careerField.entity.DepartmentCareerField;
 import com.kakao.uniscope.department.entity.Department;
+import com.kakao.uniscope.univ.entity.University;
 
 import java.util.List;
 import java.util.Set;
@@ -28,6 +30,9 @@ public record DepartmentInfoResponse(
 ) {
     public static DepartmentInfoResponse from(Department department) {
 
+        College college = department.getCollege();
+        University university = (college != null) ? college.getUniversity() : null;
+
         Set<CareerFieldDto> careerFieldDtos = department.getDepartmentCareerFields().stream()
                 .map(DepartmentCareerField::getCareerField)
                 .map(CareerFieldDto::from)
@@ -49,9 +54,9 @@ public record DepartmentInfoResponse(
                 department.getDeptEmail(),
                 department.getDeptEstablishedYear(),
                 department.getDeptIntro(),
-                department.getCollege().getUniversity().getName(),
-                department.getCollege().getUniversity().getImageUrl(),
-                department.getCollege().getCollegeName(),
+                (university != null) ? university.getName() : null,
+                (university != null) ? university.getImageUrl() : null,
+                (college != null) ? college.getCollegeName() : null,
                 department.getDeptStudentNum(),
                 professorCount,
                 careerFieldDtos,

--- a/src/test/java/com/kakao/uniscope/department/DepartmentControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/department/DepartmentControllerTest.java
@@ -30,7 +30,7 @@ public class DepartmentControllerTest {
     void 학과_상세_정보_조회_API_동작_성공() throws Exception {
         Long deptSeq = 1L;
 
-        DepartmentInfoResponse mockResponse = new DepartmentInfoResponse(1L, "", "", "", "", "", "", "", "", 0, null, null);
+        DepartmentInfoResponse mockResponse = new DepartmentInfoResponse(1L, "", "", "", "", "", "", "", "", "", "","", 0, null, null, null);
 
         when(departmentService.getDeptDetails(deptSeq)).thenReturn(mockResponse);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 🚀 작업 내용

- 학과 정보 조회 API에서 `/api/departments/{deptSeq}` 학교 로고를 추가로 반환하도록 했습니다.

## 📢 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> r : 꼭 반영 해주세요 (request changes)
> c : 웬만하면 반영해주세요 (comment)
> a : 그냥 의견 혹은 칭찬(칭찬이 중요, 개발을 계속 하게 만드는 원동력이 될 수 있음) (approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Department details now include a university image URL, enabling display of university logos/branding in department pages and listings.
  * API responses now provide imageUrl alongside university and college information for richer visual context.

* **Tests**
  * Updated tests/mocks to reflect the expanded department response payload including the new imageUrl field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->