### PR TITLE
[Weekly 11] 사용자 회원가입 시 id 중복 확인

### DIFF
--- a/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .headers(header-> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/**", "api/users//check-id").permitAll()
                         .requestMatchers("/api/users/signup", "/api/users/login", "/api/users/email/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/reviews/univ").permitAll() // 대학 리뷰 작성은 허용
                         .requestMatchers("/h2-console/**").permitAll()

--- a/src/main/java/com/kakao/uniscope/user/controller/UserController.java
+++ b/src/main/java/com/kakao/uniscope/user/controller/UserController.java
@@ -35,4 +35,10 @@ public class UserController {
         return ResponseEntity.ok(CommonResponseDto.ok("로그인에 성공했습니다.", loginResponse));
     }
 
+    // 아이디 중복 확인: 중복이면 409, 사용 가능이면 204
+    @GetMapping("/check-id")
+    public ResponseEntity<Void> checkUserId(@RequestParam String userId) {
+        boolean duplicated = userService.existsByUserId(userId);
+        return duplicated ? ResponseEntity.status(409).build() : ResponseEntity.noContent().build();
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- close:
   -  #9 
   - #74 

## 🚀 작업 내용

- UserController:
   - GET /api/users/check-id → 중복 409, 사용 가능 204
- SecurityConfig: 
   - 이메일/중복확인 엔드포인트 접근 허용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

### 📸 스크린샷 (선택) 
<img width="713" height="602" alt="image" src="https://github.com/user-attachments/assets/28835edc-ae22-4309-a33e-0f309842e9e1" />
<img width="717" height="581" alt="image" src="https://github.com/user-attachments/assets/ebf2d5ab-61b7-41dc-b60b-021790cb17cc" />
