### PR TITLE
[Weekly 11] 연도별 대학 평균 평점 추이 데이터 제공 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kakao/uniscope/college/controller/CollegeController.java
+++ b/src/main/java/com/kakao/uniscope/college/controller/CollegeController.java
@@ -3,6 +3,8 @@ package com.kakao.uniscope.college.controller;
 import com.kakao.uniscope.college.dto.CollegeDetailsResponseDto;
 import com.kakao.uniscope.college.dto.DepartmentsByCollegeResponseDto;
 import com.kakao.uniscope.college.service.CollegeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "단과대학 API", description = "단과대학에 관련된 API 입니다.")
 @RestController
 @RequestMapping("/api/college")
 public class CollegeController {
@@ -20,12 +23,14 @@ public class CollegeController {
         this.collegeService = collegeService;
     }
 
+    @Operation(summary = "단과대학의 학과 목록 조회 API", description = "collegeSeq에 해당하는 단과대학에 속한 학과 목록을 반환합니다.")
     @GetMapping("/{collegeSeq}")
     public ResponseEntity<DepartmentsByCollegeResponseDto> getDepartmentsByCollege(@PathVariable Long collegeSeq) {
         DepartmentsByCollegeResponseDto responseDto = collegeService.getDepartmentsByCollege(collegeSeq);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
+    @Operation(summary = "단과대학의 정보 조회 API", description = "collegeSeq에 해당하는 단과대학의 정보를 반환합니다.")
     @GetMapping("/{collegeSeq}/details")
     public ResponseEntity<CollegeDetailsResponseDto> getCollegeDetails(@PathVariable Long collegeSeq) {
         CollegeDetailsResponseDto responseDto = collegeService.getCollegeDetails(collegeSeq);

--- a/src/main/java/com/kakao/uniscope/common/config/SwaggerConfig.java
+++ b/src/main/java/com/kakao/uniscope/common/config/SwaggerConfig.java
@@ -1,0 +1,56 @@
+package com.kakao.uniscope.common.config;
+
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Value("${swagger.local-url}")
+    private String localServerUrl;
+
+    @Value("${swagger.prod-url}")
+    private String prodServerUrl;
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+
+        String jwtSchemeName = "jwtAuth";
+
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        // 배포 환경 URL 설정
+        Server deployServer = new Server();
+        deployServer.setUrl(prodServerUrl);
+        deployServer.setDescription("실제 배포 환경 서버");
+
+        // 로컬 환경 URL 설정
+        Server localServer = new Server();
+        localServer.setUrl(localServerUrl);
+        localServer.setDescription("로컬 개발 환경 서버");
+
+        return new OpenAPI()
+                .info(apiInfo())
+                .components(components).servers(List.of(localServer, deployServer));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Uniscope API")
+                .description("Uniscope API 명세서")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/com/kakao/uniscope/comparison/controller/ComparisonController.java
+++ b/src/main/java/com/kakao/uniscope/comparison/controller/ComparisonController.java
@@ -1,6 +1,7 @@
 package com.kakao.uniscope.comparison.controller;
 
 import com.kakao.uniscope.comparison.dto.ProfessorComparisonDto;
+import com.kakao.uniscope.comparison.dto.UnivRatingTrendResponseDto;
 import com.kakao.uniscope.comparison.dto.UniversityComparisonDto;
 import com.kakao.uniscope.comparison.service.ComparisonService;
 import com.kakao.uniscope.comparison.service.ProfessorComparisonService;
@@ -43,6 +44,20 @@ public class ComparisonController {
     ) {
         List<UniversityComparisonDto> response = comparisonService.getUniversitiesComparisonData(univSeqs);
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "학교 비교 연도별 평점 추이 데이터 조회 API", description = "1~2개 학교의 종합 평점 추이 데이터를 제공합니다. (비교하는 연도 기준 8년 전까지의 데이터를 제공합니다.")
+    @GetMapping("/university-rating-trends")
+    public ResponseEntity<UnivRatingTrendResponseDto> getUnivRatingTrendData(
+            @Parameter(
+                    description = "비교할 대학들의 고유 번호 목록 (1~2개)",
+                    schema = @Schema(type = "array", example = "1,2")
+            )
+            @RequestParam("univSeqs") List<Long> univSeqs
+    ) {
+        UnivRatingTrendResponseDto responseDto = comparisonService.getUnivRatingTrendData(univSeqs);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+
     }
 
     @Operation(summary = "교수 비교 데이터 조회 API", description = "1~3명의 교수의 간단한 정보와 각 평가 항목의 평균을 반환합니다.")

--- a/src/main/java/com/kakao/uniscope/comparison/controller/ComparisonController.java
+++ b/src/main/java/com/kakao/uniscope/comparison/controller/ComparisonController.java
@@ -4,6 +4,11 @@ import com.kakao.uniscope.comparison.dto.ProfessorComparisonDto;
 import com.kakao.uniscope.comparison.dto.UniversityComparisonDto;
 import com.kakao.uniscope.comparison.service.ComparisonService;
 import com.kakao.uniscope.comparison.service.ProfessorComparisonService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "비교 API", description = "대학, 교수 비교 관련 API입니다.")
 @RestController
 @RequestMapping("/api/comparison")
 public class ComparisonController {
@@ -26,18 +32,26 @@ public class ComparisonController {
         this.professorComparisonService = professorComparisonService;
     }
 
-    // 학교 비교 데이터 조회 API
+    @Operation(summary = "학교 비교 데이터 조회 API", description = "1~2개 학교의 간단한 정보와 각 평가 항목의 평균을 반환합니다.")
     @GetMapping("/universities")
     public ResponseEntity<List<UniversityComparisonDto>> getUniversitiesComparisonData(
+            @Parameter(
+                    description = "비교할 대학들의 고유 번호 목록 (최대 2개)",
+                    schema = @Schema(type = "array", example = "1,2")
+            )
             @RequestParam("univSeqs") List<Long> univSeqs
     ) {
         List<UniversityComparisonDto> response = comparisonService.getUniversitiesComparisonData(univSeqs);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    // 교수 비교 데이터 조회 API
+    @Operation(summary = "교수 비교 데이터 조회 API", description = "1~3명의 교수의 간단한 정보와 각 평가 항목의 평균을 반환합니다.")
     @GetMapping("/professors")
     public ResponseEntity<List<ProfessorComparisonDto>> getProfessorsComparisonData(
+            @Parameter(
+                    description = "비교할 교수들의 고유 번호 목록 (최대 3개)",
+                    schema = @Schema(type = "array", example = "1,2,3")
+            )
             @RequestParam("profSeqs") List<Long> profSeqs
     ) {
         List<ProfessorComparisonDto> response = professorComparisonService.getProfessorsComparisonData(profSeqs);

--- a/src/main/java/com/kakao/uniscope/comparison/dto/UnivRatingTrendResponseDto.java
+++ b/src/main/java/com/kakao/uniscope/comparison/dto/UnivRatingTrendResponseDto.java
@@ -1,0 +1,7 @@
+package com.kakao.uniscope.comparison.dto;
+
+import java.util.List;
+
+public record UnivRatingTrendResponseDto(
+        List<UnivYearlyRatingTrendDto> trends
+) { }

--- a/src/main/java/com/kakao/uniscope/comparison/dto/UnivYearlyRatingTrendDto.java
+++ b/src/main/java/com/kakao/uniscope/comparison/dto/UnivYearlyRatingTrendDto.java
@@ -1,0 +1,8 @@
+package com.kakao.uniscope.comparison.dto;
+
+import java.util.List;
+
+public record UnivYearlyRatingTrendDto(
+        Integer year,
+        List<UnivYearlyScoreDto> scores
+) { }

--- a/src/main/java/com/kakao/uniscope/comparison/dto/UnivYearlyScoreDto.java
+++ b/src/main/java/com/kakao/uniscope/comparison/dto/UnivYearlyScoreDto.java
@@ -1,0 +1,6 @@
+package com.kakao.uniscope.comparison.dto;
+
+public record UnivYearlyScoreDto(
+        Long univSeq,
+        Double averageScore
+) { }

--- a/src/main/java/com/kakao/uniscope/comparison/service/ComparisonService.java
+++ b/src/main/java/com/kakao/uniscope/comparison/service/ComparisonService.java
@@ -1,17 +1,14 @@
 package com.kakao.uniscope.comparison.service;
 
 import com.kakao.uniscope.common.exception.ResourceNotFoundException;
-import com.kakao.uniscope.comparison.dto.ChartScoreDto;
-import com.kakao.uniscope.comparison.dto.UniversityComparisonDto;
+import com.kakao.uniscope.comparison.dto.*;
 import com.kakao.uniscope.comparison.exception.ComparisonException;
 import com.kakao.uniscope.univ.entity.University;
 import com.kakao.uniscope.univ.repository.UnivRepository;
-import com.kakao.uniscope.univ.review.entity.UnivReview;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,52 +16,46 @@ import java.util.stream.Collectors;
 public class ComparisonService {
 
     private final UnivRepository univRepository;
+    private final UnivComparisonMapper univComparisonMapper;
 
     public ComparisonService(UnivRepository univRepository) {
         this.univRepository = univRepository;
+        this.univComparisonMapper = new UnivComparisonMapper();
     }
 
     // 대학 비교를 위한 로직
-    public List<UniversityComparisonDto> getUniversitiesComparisonData(List<Long> univIds) {
-        if (univIds == null || univIds.isEmpty() || univIds.size() > 2) {
-            throw new ComparisonException("비교할 대학 ID는 1개 이상 2개 이하로 제공되어야 합니다.");
-        }
+    public List<UniversityComparisonDto> getUniversitiesComparisonData(List<Long> univSeqs) {
+        validateUnivSeqs(univSeqs);
 
-        List<University> universities = univRepository.findWithReviewsByUnivSeqIn(univIds);
+        List<University> universities = univRepository.findWithReviewsByUnivSeqIn(univSeqs);
 
-        if (universities.size() != univIds.size()) {
+        if (universities.size() != univSeqs.size()) {
             throw new ResourceNotFoundException("요청된 일부 대학 정보를 찾을 수 없거나 존재하지 않습니다.");
         }
 
         return universities.stream()
-                .map(this::toUniversityComparisonDto)
+                .map(univComparisonMapper::toUniversityComparisonDto)
                 .collect(Collectors.toList());
     }
 
-    private UniversityComparisonDto toUniversityComparisonDto(University univ) {
+    // 연도별 평균 평점 추이 데이터 조회 로직
+    public UnivRatingTrendResponseDto getUnivRatingTrendData(List<Long> univSeqs) {
+        validateUnivSeqs(univSeqs);
 
-        ChartScoreDto scores = calculateScores(univ.getReviews());
+        List<University> universities = univRepository.findWithReviewsByUnivSeqIn(univSeqs);
 
-        return UniversityComparisonDto.builder()
-                .univSeq(univ.getUnivSeq())
-                .univName(univ.getName())
-                .address(univ.getAddress())
-                .tel(univ.getTel())
-                .scores(scores)
-                .build();
-    }
-
-    private ChartScoreDto calculateScores(Set<UnivReview> reviews) {
-        if (reviews == null || reviews.isEmpty()) {
-            return ChartScoreDto.empty();
+        if (universities.size() != univSeqs.size()) {
+            throw new ResourceNotFoundException("요청된 일부 대학 정보를 찾을 수 없거나 존재하지 않습니다.");
         }
 
-        double foodAvg = reviews.stream().mapToInt(r -> r.getFoodScore() != null ? r.getFoodScore() : 0).average().orElse(0.0);
-        double dormAvg = reviews.stream().mapToInt(r -> r.getDormScore() != null ? r.getDormScore() : 0).average().orElse(0.0);
-        double convAvg = reviews.stream().mapToInt(r -> r.getConvScore() != null ? r.getConvScore() : 0).average().orElse(0.0);
-        double campusAvg = reviews.stream().mapToInt(r -> r.getCampusScore() != null ? r.getCampusScore() : 0).average().orElse(0.0);
-        double welfareAvg = reviews.stream().mapToInt(r -> r.getWelfareScore() != null ? r.getWelfareScore() : 0).average().orElse(0.0);
+        List<UnivYearlyRatingTrendDto> trends = univComparisonMapper.generateYearlyTrends(universities);
 
-        return new ChartScoreDto(foodAvg, dormAvg, convAvg, campusAvg, welfareAvg);
+        return new UnivRatingTrendResponseDto(trends);
+    }
+
+    private void validateUnivSeqs(List<Long> univSeqs) {
+        if (univSeqs == null || univSeqs.isEmpty() || univSeqs.size() > 2) {
+            throw new ComparisonException("비교할 대학 Seq는 1개 이상 2개 이하로 제공되어야 합니다.");
+        }
     }
 }

--- a/src/main/java/com/kakao/uniscope/comparison/service/UnivComparisonMapper.java
+++ b/src/main/java/com/kakao/uniscope/comparison/service/UnivComparisonMapper.java
@@ -1,0 +1,79 @@
+package com.kakao.uniscope.comparison.service;
+
+import com.kakao.uniscope.comparison.dto.ChartScoreDto;
+import com.kakao.uniscope.comparison.dto.UnivYearlyRatingTrendDto;
+import com.kakao.uniscope.comparison.dto.UnivYearlyScoreDto;
+import com.kakao.uniscope.comparison.dto.UniversityComparisonDto;
+import com.kakao.uniscope.univ.entity.University;
+import com.kakao.uniscope.univ.review.entity.UnivReview;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class UnivComparisonMapper {
+
+    public UniversityComparisonDto toUniversityComparisonDto(University univ) {
+        ChartScoreDto scores = calculateScores(univ.getReviews());
+
+        return UniversityComparisonDto.builder()
+                .univSeq(univ.getUnivSeq())
+                .univName(univ.getName())
+                .address(univ.getAddress())
+                .tel(univ.getTel())
+                .scores(scores)
+                .build();
+    }
+
+    public ChartScoreDto calculateScores(Set<UnivReview> reviews) {
+        if (reviews == null || reviews.isEmpty()) {
+            return ChartScoreDto.empty();
+        }
+
+        double foodAvg = reviews.stream().mapToInt(r -> r.getFoodScore() != null ? r.getFoodScore() : 0).average().orElse(0.0);
+        double dormAvg = reviews.stream().mapToInt(r -> r.getDormScore() != null ? r.getDormScore() : 0).average().orElse(0.0);
+        double convAvg = reviews.stream().mapToInt(r -> r.getConvScore() != null ? r.getConvScore() : 0).average().orElse(0.0);
+        double campusAvg = reviews.stream().mapToInt(r -> r.getCampusScore() != null ? r.getCampusScore() : 0).average().orElse(0.0);
+        double welfareAvg = reviews.stream().mapToInt(r -> r.getWelfareScore() != null ? r.getWelfareScore() : 0).average().orElse(0.0);
+
+        return new ChartScoreDto(foodAvg, dormAvg, convAvg, campusAvg, welfareAvg);
+    }
+
+    // 연도별 추이 데이터 생성
+    public List<UnivYearlyRatingTrendDto> generateYearlyTrends(List<University> universities) {
+        List<UnivYearlyRatingTrendDto> trends = new ArrayList<>();
+
+        int currentYear = LocalDateTime.now().getYear();
+        int startYear = currentYear - 7;
+
+        for (int year = startYear; year <= currentYear; year++) {
+            List<UnivYearlyScoreDto> yearlyScores = new ArrayList<>();
+
+            for (University univ : universities) {
+                Double avgScore = calculateAverageForYear(univ.getReviews(), year);
+                yearlyScores.add(new UnivYearlyScoreDto(univ.getUnivSeq(), avgScore));
+            }
+
+            trends.add(new UnivYearlyRatingTrendDto(year, yearlyScores));
+        }
+
+        trends.sort(Comparator.comparing(UnivYearlyRatingTrendDto::year));
+        return trends;
+    }
+
+    private Double calculateAverageForYear(Set<UnivReview> reviews, int targetYear) {
+        if (reviews == null || reviews.isEmpty()) return 0.0;
+
+        Set<UnivReview> reviewsInYear = reviews.stream()
+                .filter(r -> r.getCreateDate() != null && r.getCreateDate().getYear() == targetYear)
+                .collect(Collectors.toSet());
+
+        // University 엔티티의 calculateAvgRating 정적 메서드를 재사용하여 중복 제거
+        return University.calculateAvgRating(reviewsInYear);
+    }
+}

--- a/src/main/java/com/kakao/uniscope/department/controller/DepartmentController.java
+++ b/src/main/java/com/kakao/uniscope/department/controller/DepartmentController.java
@@ -2,6 +2,8 @@ package com.kakao.uniscope.department.controller;
 
 import com.kakao.uniscope.department.dto.DepartmentInfoResponse;
 import com.kakao.uniscope.department.service.DepartmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "학과 API", description = "학과 관련 API 입니다.")
 @RestController
 @RequestMapping("/api/departments")
 public class DepartmentController {
@@ -19,6 +22,7 @@ public class DepartmentController {
         this.departmentService = departmentService;
     }
 
+    @Operation(summary = "학과 정보 조회 API", description = "deptSeq에 해당하는 학과의 정보를 반환합니다.")
     @GetMapping("/{deptSeq}")
     public ResponseEntity<DepartmentInfoResponse> getDeptDetails(@PathVariable Long deptSeq) {
         DepartmentInfoResponse response = departmentService.getDeptDetails(deptSeq);

--- a/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
+++ b/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
@@ -1,8 +1,10 @@
 package com.kakao.uniscope.department.dto;
 
+import com.kakao.uniscope.college.entity.College;
 import com.kakao.uniscope.department.careerField.dto.CareerFieldDto;
 import com.kakao.uniscope.department.careerField.entity.DepartmentCareerField;
 import com.kakao.uniscope.department.entity.Department;
+import com.kakao.uniscope.univ.entity.University;
 
 import java.util.List;
 import java.util.Set;
@@ -19,6 +21,7 @@ public record DepartmentInfoResponse(
         String deptEstablishedYear,
         String deptIntro,
         String univName,
+        String imageUrl,
         String collegeName,
         Integer deptStudentNum,
         Integer professorCount,
@@ -26,6 +29,9 @@ public record DepartmentInfoResponse(
         List<ProfessorDto> professors
 ) {
     public static DepartmentInfoResponse from(Department department) {
+
+        College college = department.getCollege();
+        University university = (college != null) ? college.getUniversity() : null;
 
         Set<CareerFieldDto> careerFieldDtos = department.getDepartmentCareerFields().stream()
                 .map(DepartmentCareerField::getCareerField)
@@ -48,8 +54,9 @@ public record DepartmentInfoResponse(
                 department.getDeptEmail(),
                 department.getDeptEstablishedYear(),
                 department.getDeptIntro(),
-                department.getCollege().getUniversity().getName(),
-                department.getCollege().getCollegeName(),
+                (university != null) ? university.getName() : null,
+                (university != null) ? university.getImageUrl() : null,
+                (college != null) ? college.getCollegeName() : null,
                 department.getDeptStudentNum(),
                 professorCount,
                 careerFieldDtos,

--- a/src/main/java/com/kakao/uniscope/professor/controller/ProfController.java
+++ b/src/main/java/com/kakao/uniscope/professor/controller/ProfController.java
@@ -3,7 +3,10 @@ package com.kakao.uniscope.professor.controller;
 import com.kakao.uniscope.professor.dto.LectureReviewPageResponseDto;
 import com.kakao.uniscope.professor.dto.ProfResponseDto;
 import com.kakao.uniscope.professor.service.ProfService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "교수 API", description = "교수 관련 API 입니다.")
 @RestController
 @RequestMapping("/api/prof")
 @RequiredArgsConstructor
@@ -20,16 +24,18 @@ public class ProfController {
 
     private final ProfService profService;
 
+    @Operation(summary = "교수 정보 조회 API", description = "특정 교수의 상세 정보와 담당 강의, 교수 리뷰를 조회하는 API 입니다.")
     @GetMapping("/{prof_seq}")
     public ResponseEntity<ProfResponseDto> getProfessorDetails(@PathVariable("prof_seq") Long profSeq) {
         ProfResponseDto response = profService.getProfessorDetails(profSeq);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "교수의 강의 목록 조회 API", description = "특정 교수의 전체 강의 목록을 최신순으로 페이지네이션하여 조회합니다.")
     @GetMapping("/{prof_seq}/reviews")
     public ResponseEntity<LectureReviewPageResponseDto> getProfessorLectureReviews(
             @PathVariable("prof_seq") Long profSeq,
-            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
 
         LectureReviewPageResponseDto response = profService.getProfessorLectureReviews(profSeq, pageable);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/kakao/uniscope/search/controller/SearchController.java
+++ b/src/main/java/com/kakao/uniscope/search/controller/SearchController.java
@@ -6,7 +6,10 @@ import com.kakao.uniscope.search.dto.UnivDeptSearchResponseDto;
 import com.kakao.uniscope.search.dto.UnivProfSearchResponseDto;
 import com.kakao.uniscope.search.dto.UnivSearchResponseDto;
 import com.kakao.uniscope.search.service.SearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "통합 검색 API", description = "대학명, 학과명, 교수명 등을 조합하여 정보를 검색합니다.")
 @RestController
 @RequestMapping("/api/search")
 @RequiredArgsConstructor
@@ -22,42 +26,42 @@ public class SearchController {
 
     private final SearchService searchService;
 
-    // 1. 대학 검색
+    @Operation(summary = "단일 대학 검색", description = "키워드를 포함하는 대학 목록을 검색하고 페이지네이션하여 반환합니다.")
     @GetMapping("/univ")
     public ResponseEntity<UnivSearchResponseDto> searchUniversity(
             @RequestParam String keyword,
-            @PageableDefault Pageable pageable
+            @ParameterObject @PageableDefault Pageable pageable
     ) {
         UnivSearchResponseDto response = searchService.searchUniversity(keyword, pageable);
         return ResponseEntity.ok(response);
     }
 
-    // 2. 교수 검색
+    @Operation(summary = "단일 교수 검색", description = "키워드를 포함하는 교수 목록을 검색하고 페이지네이션하여 반환합니다.")
     @GetMapping("/prof")
     public ResponseEntity<ProfSearchResponseDto> searchProfessor(
             @RequestParam String keyword,
-            @PageableDefault Pageable pageable
+            @ParameterObject @PageableDefault Pageable pageable
     ) {
         ProfSearchResponseDto response = searchService.searchProfessor(keyword, pageable);
         return ResponseEntity.ok(response);
     }
 
-    // 3. 학과 검색
+    @Operation(summary = "단일 학과 검색", description = "키워드를 포함하는 학과 목록을 검색하고 페이지네이션하여 반환합니다.")
     @GetMapping("/dept")
     public ResponseEntity<DeptSearchResponseDto> searchDepartment(
             @RequestParam String keyword,
-            @PageableDefault Pageable pageable
+            @ParameterObject @PageableDefault Pageable pageable
     ) {
         DeptSearchResponseDto response = searchService.searchDepartment(keyword, pageable);
         return ResponseEntity.ok(response);
     }
 
-    // 4. 대학 + 학과 검색
+    @Operation(summary = "대학 + 학과 복합 검색", description = "특정 대학 내에서 학과명을 검색합니다.")
     @GetMapping("/univ-dept")
     public ResponseEntity<UnivDeptSearchResponseDto> searchUnivAndDept(
             @RequestParam String univKeyword,
             @RequestParam String deptKeyword,
-            @PageableDefault Pageable pageable
+            @ParameterObject @PageableDefault Pageable pageable
     ) {
         UnivDeptSearchResponseDto response = searchService.searchUnivAndDept(
                 univKeyword, deptKeyword, pageable
@@ -65,12 +69,12 @@ public class SearchController {
         return ResponseEntity.ok(response);
     }
 
-    // 5. 대학 + 교수 검색
+    @Operation(summary = "대학 + 교수 복합 검색", description = "특정 대학 내에서 교수명을 검색합니다.")
     @GetMapping("/univ-prof")
     public ResponseEntity<UnivProfSearchResponseDto> searchUnivAndProf(
             @RequestParam String univKeyword,
             @RequestParam String profKeyword,
-            @PageableDefault Pageable pageable
+            @ParameterObject @PageableDefault Pageable pageable
     ) {
         UnivProfSearchResponseDto response = searchService.searchUnivAndProf(
                 univKeyword, profKeyword, pageable

--- a/src/main/java/com/kakao/uniscope/univ/controller/UnivController.java
+++ b/src/main/java/com/kakao/uniscope/univ/controller/UnivController.java
@@ -5,6 +5,10 @@ import com.kakao.uniscope.univ.dto.UnivResponseDto;
 import com.kakao.uniscope.univ.review.dto.UnivReviewResponseDto;
 import com.kakao.uniscope.univ.review.service.UnivReviewService;
 import com.kakao.uniscope.univ.service.UnivService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "대학 API", description = "대학 관련 API 입니다.")
 @RestController
 @RequestMapping("/api/univ")
 public class UnivController {
@@ -27,6 +32,7 @@ public class UnivController {
         this.univReviewService = univReviewService;
     }
 
+    @Operation(summary = "대학 정보 조회 API", description = "univSeq에 해당하는 대학의 정보를 조회하는 API입니다.")
     @GetMapping("/{univSeq}")
     public ResponseEntity<UnivResponseDto> getUniversityInfo(@PathVariable Long univSeq) {
 
@@ -35,16 +41,19 @@ public class UnivController {
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
+    @Operation(summary = "대학 리뷰 목록 조회 API", description = "특정 대학의 전체 리뷰 목록을 최신순으로 페이지네이션하여 조회합니다.")
     @GetMapping("/{univSeq}/reviews")
     public ResponseEntity<UnivReviewResponseDto> getAllUnivReviews(
+            @Parameter(name = "univSeq", description = "조회할 대학의 고유 번호", example = "1")
             @PathVariable Long univSeq,
-            @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable
+
+            @ParameterObject @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         UnivReviewResponseDto responseDto = univReviewService.getAllUnivReviews(univSeq, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
-    // 대학의 모든 단과대학 목록을 반환하는 API
+    @Operation(summary = "단과대학 목록 조회 API", description = "특정 대학에 소속된 모든 단과대학 목록과 학과 수를 조회합니다.")
     @GetMapping("/{univSeq}/colleges")
     public ResponseEntity<CollegeListResponseDto> getAllCollegeList(@PathVariable Long univSeq) {
         CollegeListResponseDto responseDto = univService.getAllCollegeList(univSeq);

--- a/src/main/java/com/kakao/uniscope/univ/entity/University.java
+++ b/src/main/java/com/kakao/uniscope/univ/entity/University.java
@@ -71,10 +71,14 @@ public class University {
     }
 
     public double getAverageRating() {
-        if (this.reviews == null || this.reviews.isEmpty()) {
+        return calculateAvgRating(this.reviews);
+    }
+
+    public static double calculateAvgRating(Set<UnivReview> reviews) {
+        if (reviews == null || reviews.isEmpty()) {
             return 0.0;
         }
-        double totalSum = this.reviews.stream()
+        double totalSum = reviews.stream()
                 .flatMapToInt(review -> {
                     int food = review.getFoodScore() != null ? review.getFoodScore() : 0;
                     int dorm = review.getDormScore() != null ? review.getDormScore() : 0;
@@ -85,7 +89,7 @@ public class University {
                 })
                 .sum();
 
-        long totalCount = (long) this.reviews.size() * 5;
+        long totalCount = (long) reviews.size() * 5;
 
         return totalSum / totalCount;
     }

--- a/src/main/java/com/kakao/uniscope/univ/review/controller/UnivReviewController.java
+++ b/src/main/java/com/kakao/uniscope/univ/review/controller/UnivReviewController.java
@@ -3,6 +3,8 @@ package com.kakao.uniscope.univ.review.controller;
 import com.kakao.uniscope.univ.review.dto.ReviewCreateResponse;
 import com.kakao.uniscope.univ.review.dto.UnivReviewRequest;
 import com.kakao.uniscope.univ.review.service.UnivReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "리뷰 API", description = "리뷰 관련 API 입니다.")
 @RestController
 @RequestMapping("/api/reviews/univ")
 public class UnivReviewController {
@@ -21,7 +24,7 @@ public class UnivReviewController {
         this.univReviewService = univReviewService;
     }
 
-    // 대학 평가 작성 API
+    @Operation(summary = "대학 리뷰 작성 API", description = "대학 리뷰를 작성하는 API입니다.")
     @PostMapping
     public ResponseEntity<ReviewCreateResponse> createUnivReview(
             @Valid @RequestBody UnivReviewRequest request

--- a/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/uniscope/user/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/signup", "/api/users/login", "/api/users/email/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/reviews/univ").permitAll() // 대학 리뷰 작성은 허용
                         .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/kakao/uniscope/user/controller/UserController.java
+++ b/src/main/java/com/kakao/uniscope/user/controller/UserController.java
@@ -5,6 +5,8 @@ import com.kakao.uniscope.user.dto.UserLoginRequestDto;
 import com.kakao.uniscope.user.dto.UserLoginResponseDto;
 import com.kakao.uniscope.user.dto.UserSignupRequestDto;
 import com.kakao.uniscope.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "유저 관련 API", description = "유저 관련 API 입니다.")
 @Slf4j
 @RestController
 @RequestMapping("/api/users")
@@ -20,7 +23,7 @@ public class UserController {
 
     private final UserService userService;
 
-    //회원가입
+    @Operation(summary = "회원가입", description = "새로운 사용자 계정을 생성합니다.")
     @PostMapping("/signup")
     public ResponseEntity<CommonResponseDto<Void>> signup(@Valid @RequestBody UserSignupRequestDto requestDto) {
         userService.signup(requestDto);
@@ -28,7 +31,7 @@ public class UserController {
                 .body(CommonResponseDto.ok("회원가입이 완료되었습니다."));
     }
 
-    //로그인
+    @Operation(summary = "로그인 및 JWT 발급", description = "아이디와 비밀번호를 검증하고 JWT 토큰을 발급합니다.")
     @PostMapping("/login")
     public ResponseEntity<CommonResponseDto<UserLoginResponseDto>> login(@Valid @RequestBody UserLoginRequestDto requestDto) {
         UserLoginResponseDto loginResponse = userService.login(requestDto);

--- a/src/main/java/com/kakao/uniscope/user/controller/UserEmailController.java
+++ b/src/main/java/com/kakao/uniscope/user/controller/UserEmailController.java
@@ -4,6 +4,8 @@ import com.kakao.uniscope.user.dto.CommonResponseDto;
 import com.kakao.uniscope.user.dto.SendCodeRequest;
 import com.kakao.uniscope.user.dto.VerifyCodeRequest;
 import com.kakao.uniscope.user.service.EmailService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "유저 관련 API")
 @RestController
 @RequestMapping("/api/users/email")
 @RequiredArgsConstructor
@@ -20,12 +23,14 @@ public class UserEmailController {
 
     private final EmailService emailService;
 
+    @Operation(summary = "인증 코드 전송", description = "입력된 이메일 주소로 인증 코드를 전송합니다.")
     @PostMapping("/send-code")
     public ResponseEntity<Void> sendCode(@RequestBody SendCodeRequest request) {
         emailService.sendVerificationCode(request.email());
         return ResponseEntity.noContent().build(); // 204
     }
 
+    @Operation(summary = "인증 코드 확인", description = "이메일로 전송된 인증 코드가 일치하는지 확인합니다.")
     @PostMapping("/verify-code")
     public ResponseEntity<Void> verifyCode(@RequestBody VerifyCodeRequest request) {
         boolean verified = emailService.verifyCode(request.email(), request.code());

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -23,3 +23,7 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   token-validity-in-seconds: 3600
+
+swagger:
+  local-url: http://localhost:8080
+  prod-url: http://13.125.1.77:8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 spring.h2.console.enabled=true
+
+swagger.local-url=http://localhost:8080
+swagger.prod-url=http://13.125.1.77:8080

--- a/src/test/java/com/kakao/uniscope/college/CollegeControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/college/CollegeControllerTest.java
@@ -36,7 +36,7 @@ public class CollegeControllerTest {
     void getDepartmentsByCollege_Success() throws Exception {
 
         Long collegeSeq = 1L;
-        DepartmentDto mockDepartmentDto = new DepartmentDto(1L, "컴퓨터공학과", "http://cs.ac.kr", "", "", "", "", "", "", 1, 2, 0.1);
+        DepartmentDto mockDepartmentDto = new DepartmentDto(1L, "컴퓨터공학과", "http://cs.ac.kr", "", "", "", "", "", "", 1, 2, 0.1, "");
         DepartmentsByCollegeResponseDto mockResponseDto = new DepartmentsByCollegeResponseDto(List.of(mockDepartmentDto));
 
         when(collegeService.getDepartmentsByCollege(collegeSeq)).thenReturn(mockResponseDto);

--- a/src/test/java/com/kakao/uniscope/department/DepartmentControllerTest.java
+++ b/src/test/java/com/kakao/uniscope/department/DepartmentControllerTest.java
@@ -30,7 +30,7 @@ public class DepartmentControllerTest {
     void 학과_상세_정보_조회_API_동작_성공() throws Exception {
         Long deptSeq = 1L;
 
-        DepartmentInfoResponse mockResponse = new DepartmentInfoResponse(1L, "", "", "", "", "", "", "", "", 0, null, null);
+        DepartmentInfoResponse mockResponse = new DepartmentInfoResponse(1L, "", "", "", "", "", "", "", "", "", "","", 0, null, null, null);
 
         when(departmentService.getDeptDetails(deptSeq)).thenReturn(mockResponse);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #77

close: #77 

## 🚀 작업 내용 (변경 사항)

현재 연도부터 8년 전까지의 연도별 종합 평균 평점 추이 데이터를 제공하는 API를 구현했습니다.

[주요 변경 사항]

- `getUnivRatingTrendData` 메서드를 추가하여 8년간의 연도별 평균 평점 추이 데이터를 제공
- ComparisonService에서 ComparisonMapper로 데이터 가공 및 변환 로직을 분리
- 유효성 검증과 평균 계산 로직의 코드 중복을 제거

## 📢 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 서비스 레이어 코드를 위주로 봐주시면 감사하겠습니다.
> -> 로직에 오류가 없는지, 혹은 불필요한 계산 등을 수행하는지
> -> 그 밖에도 리팩토링 할 만한 요소가 있다면 작성해주시면 감사하겠습니다.
> 
> r : 꼭 반영 해주세요 (request changes)
> c : 웬만하면 반영해주세요 (comment)
> a : 그냥 의견 혹은 칭찬(칭찬이 중요, 개발을 계속 하게 만드는 원동력이 될 수 있음) (approve)