### PR TITLE
Refactor: dto 이름을 엔티티와 명확히 구분되도록 변경

### DIFF
--- a/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
+++ b/src/main/java/com/kakao/uniscope/department/dto/DepartmentInfoResponse.java
@@ -26,7 +26,7 @@ public record DepartmentInfoResponse(
         Integer deptStudentNum,
         Integer professorCount,
         Set<CareerFieldDto> careerFields,
-        List<ProfessorDto> professors
+        List<ProfessorSummaryDto> professors
 ) {
     public static DepartmentInfoResponse from(Department department) {
 
@@ -40,8 +40,8 @@ public record DepartmentInfoResponse(
 
         int professorCount = department.getProfessors() != null ? department.getProfessorCount() : 0;
 
-        List<ProfessorDto> professorDtos = department.getProfessors().stream()
-                .map(ProfessorDto::from)
+        List<ProfessorSummaryDto> professorSummaryDtos = department.getProfessors().stream()
+                .map(ProfessorSummaryDto::from)
                 .toList();
 
         return new DepartmentInfoResponse(
@@ -60,7 +60,7 @@ public record DepartmentInfoResponse(
                 department.getDeptStudentNum(),
                 professorCount,
                 careerFieldDtos,
-                professorDtos
+                professorSummaryDtos
         );
     }
 }

--- a/src/main/java/com/kakao/uniscope/department/dto/ProfessorSummaryDto.java
+++ b/src/main/java/com/kakao/uniscope/department/dto/ProfessorSummaryDto.java
@@ -2,7 +2,7 @@ package com.kakao.uniscope.department.dto;
 
 import com.kakao.uniscope.professor.entity.Professor;
 
-public record ProfessorDto(
+public record ProfessorSummaryDto(
         Long profSeq,
         String profName,
         String profEmail,
@@ -10,8 +10,8 @@ public record ProfessorDto(
         String office,
         String imageUrl
 ) {
-    public static ProfessorDto from(Professor professor) {
-        return new ProfessorDto(
+    public static ProfessorSummaryDto from(Professor professor) {
+        return new ProfessorSummaryDto(
                 professor.getProfSeq(),
                 professor.getProfName(),
                 professor.getProfEmail(),


### PR DESCRIPTION
## #️⃣연관된 이슈

## 🚀 작업 내용

Swagger에서 학과 정보 조회 API의 response 형식이 실제와 맞지 않아 수정했습니다.

- ProfessorDto -> ProfessorSummaryDto 로 변경
- `SpringDoc/Jackson` 이 복잡한 구조의 엔티티에서 연관관계 필드를 잘못 유추하여 응답 예시를 생성할 수 있어
- dto 이름을 변경함으로써 문제를 해결했습니다.

### 📸 스크린샷

**수정 전 응답**

<img width="252" height="400" alt="image" src="https://github.com/user-attachments/assets/45631dc2-050e-48c4-b96c-4666ac9a974e" />

**수정 후 응답**

<img width="284" height="298" alt="image" src="https://github.com/user-attachments/assets/c0d34006-9625-4b2f-8a9f-8df9d1b33d58" />


## 📢 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> r : 꼭 반영 해주세요 (request changes)
> c : 웬만하면 반영해주세요 (comment)
> a : 그냥 의견 혹은 칭찬(칭찬이 중요, 개발을 계속 하게 만드는 원동력이 될 수 있음) (approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the department information API response to include simplified professor summaries instead of full professor details, altering the structure of returned professor data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->