### PR TITLE
Refactor: 강의 테이블의 영어 강의 여부, 상대평가 여부 컬럼 삭제

### DIFF
--- a/src/main/java/com/kakao/uniscope/lecture/entity/Lecture.java
+++ b/src/main/java/com/kakao/uniscope/lecture/entity/Lecture.java
@@ -33,14 +33,8 @@ public class Lecture {
     @Column(name = "LEC_NAME")
     private String lecName;
 
-    @Column(name = "ENG_LEC_YN")
-    private String engLecYn;
-
     @Column(name = "PF_YN")
     private String pnf;
-
-    @Column(name = "REL_YN")
-    private String relYn;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "PROF_SEQ")

--- a/src/main/java/com/kakao/uniscope/professor/controller/ProfController.java
+++ b/src/main/java/com/kakao/uniscope/professor/controller/ProfController.java
@@ -31,7 +31,7 @@ public class ProfController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "교수의 강의 목록 조회 API", description = "특정 교수의 전체 강의 목록을 최신순으로 페이지네이션하여 조회합니다.")
+    @Operation(summary = "교수의 강의 리뷰 목록 조회 API", description = "특정 교수의 전체 강의 리뷰 목록을 최신순으로 페이지네이션하여 조회합니다.")
     @GetMapping("/{prof_seq}/reviews")
     public ResponseEntity<LectureReviewPageResponseDto> getProfessorLectureReviews(
             @PathVariable("prof_seq") Long profSeq,

--- a/src/main/java/com/kakao/uniscope/professor/dto/LectureSimpleDto.java
+++ b/src/main/java/com/kakao/uniscope/professor/dto/LectureSimpleDto.java
@@ -5,17 +5,13 @@ import com.kakao.uniscope.lecture.entity.Lecture;
 public record LectureSimpleDto(
         Long id,
         String name,
-        String engLecYn,
         String pnf,
-        String relYn,
         Integer reviewCount
 ) {
     public static LectureSimpleDto from(Lecture lecture) {
         return new LectureSimpleDto(
                 lecture.getLecSeq(),
                 lecture.getLecName(),
-                lecture.getEngLecYn(),
-                lecture.getPnf(),
                 lecture.getPnf(),
                 lecture.getLectureReviews().size()
         );


### PR DESCRIPTION
## #️⃣연관된 이슈

## 🚀 작업 내용

- 강의 테이블의 영어 강의 여부, 상대평가 여부 컬럼을 삭제했습니다.
- 또한, `/api/prof/{prof_seq}/reviews` 에 대한 잘못된 swagger description 내용을 수정했습니다.

### 📸 스크린샷

<img width="316" height="288" alt="image" src="https://github.com/user-attachments/assets/46b50d3e-1891-4b78-8319-d1bf0738c817" />

## 📢 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> r : 꼭 반영 해주세요 (request changes)
> c : 웬만하면 반영해주세요 (comment)
> a : 그냥 의견 혹은 칭찬(칭찬이 중요, 개발을 계속 하게 만드는 원동력이 될 수 있음) (approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API endpoint documentation to accurately describe lecture reviews retrieval.

* **Refactor**
  * Removed unused fields from lecture data structures and corresponding data transfer objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->